### PR TITLE
[#47] kakao map 클릭 이벤트 관련 버그 및 오류 해결

### DIFF
--- a/src/app/(home)/_components/Map.tsx
+++ b/src/app/(home)/_components/Map.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, forwardRef, useCallback, useEffect, useRef, useState } from 'react';
+import { ForwardedRef, forwardRef, useCallback, useEffect, useState } from 'react';
 import { CreateMarkerParams, MovePositionParams } from '@/hooks/useCreateKakaoMap';
 import useGeolocation from '@/hooks/useGeolocation';
 import markerImg from '../../../../public/oh.png';
@@ -17,11 +17,22 @@ interface MapProps {
     markerSize,
   }: CreateMarkerParams) => kakao.maps.Marker;
   isLoad: boolean;
+  handleMouseUp: () => void;
+  timerRef: React.MutableRefObject<NodeJS.Timeout | null>;
 }
 
 const Map = forwardRef(
   (
-    { map, removeMarker, movePosition, changeCenter, createMarker, isLoad }: MapProps,
+    {
+      map,
+      removeMarker,
+      movePosition,
+      changeCenter,
+      createMarker,
+      isLoad,
+      handleMouseUp,
+      timerRef,
+    }: MapProps,
     mapRef: ForwardedRef<HTMLDivElement>,
   ) => {
     const [createdPositionCoordinates, setCreatedPositionCoordinates] =
@@ -67,8 +78,6 @@ const Map = forwardRef(
       }
     }, [createMarker, isLoad]);
 
-    const timerRef = useRef<NodeJS.Timeout | null>(null);
-
     const handleMouseDown = useCallback(
       (e: kakao.maps.event.MouseEvent) => {
         timerRef.current = setTimeout(() => {
@@ -85,14 +94,8 @@ const Map = forwardRef(
           }
         }, 1000);
       },
-      [map, movePosition, createdPositionCoordinates],
+      [timerRef, createdPositionCoordinates, map, movePosition],
     );
-
-    const handleMouseUp = () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
-    };
 
     const handleTouchStart = useCallback(
       (e: TouchEvent) => {
@@ -114,7 +117,7 @@ const Map = forwardRef(
           }, 1000);
         }
       },
-      [createdPositionCoordinates, map, movePosition],
+      [createdPositionCoordinates, map, movePosition, timerRef],
     );
 
     useEffect(() => {
@@ -135,7 +138,7 @@ const Map = forwardRef(
         }
         mapContainer.removeEventListener('touchstart', handleTouchStart);
       };
-    }, [handleMouseDown, handleTouchStart, map]);
+    }, [handleMouseDown, handleMouseUp, handleTouchStart, map]);
 
     return (
       <div

--- a/src/app/(home)/_components/MapSection.tsx
+++ b/src/app/(home)/_components/MapSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import CreateBtn from '@/app/_components/CreateBtn';
 import MGCList from '@/app/_components/MGCList/MGCList';
 import useCreateKakaoMap from '@/hooks/useCreateKakaoMap';
@@ -13,20 +13,28 @@ const MapSection = ({ data }: MGCListType) => {
   const [open, setOpen] = useState(false);
   const { centerPosition } = useCenterPosition();
 
-  const openBottomSheetAndUpdate = (mapData: MGCSummary[]) => {
-    setMGCDataList(mapData);
-    setOpen(true);
-  };
-
   useEffect(() => {
     if (data) {
       setMGCDataList(data);
     }
   }, [data]);
 
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleMouseUp = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+  };
+
+  const openBottomSheetAndUpdate = (mapData: MGCSummary[]) => {
+    setMGCDataList(mapData);
+    setOpen(true);
+  };
+
   const { clusterer, map, mapRef, createMarker, changeCenter, removeMarker, movePosition, isLoad } =
-    useCreateKakaoMap();
-  const renderMarker = useRenderMarkerByData(openBottomSheetAndUpdate);
+    useCreateKakaoMap({ isCustomlevelControl: false, handleMouseUp: handleMouseUp });
+  const renderMarker = useRenderMarkerByData(openBottomSheetAndUpdate, handleMouseUp);
 
   useEffect(() => {
     if (clusterer && data) {
@@ -52,6 +60,8 @@ const MapSection = ({ data }: MGCListType) => {
         changeCenter={changeCenter}
         movePosition={movePosition}
         ref={mapRef}
+        timerRef={timerRef}
+        handleMouseUp={handleMouseUp}
       />
 
       <div className="absolute bottom-0 right-24pxr z-30">

--- a/src/hooks/useCreateKakaoMap.ts
+++ b/src/hooks/useCreateKakaoMap.ts
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+interface CreateKakaoMapProps {
+  isCustomlevelControl: boolean;
+  handleMouseUp?: () => void;
+}
+
 export interface CreateMarkerParams {
   latitude: number;
   longitude: number;
@@ -18,7 +23,7 @@ export interface MovePositionParams {
   longitude: number;
 }
 
-const useCreateKakaoMap = (isCustomlevelControl = false) => {
+const useCreateKakaoMap = ({ isCustomlevelControl, handleMouseUp }: CreateKakaoMapProps) => {
   const mapRef = useRef<HTMLDivElement>(null);
   const [map, setMap] = useState<kakao.maps.Map>();
   const [clusterer, setClusterer] = useState<kakao.maps.MarkerClusterer>();
@@ -50,6 +55,7 @@ const useCreateKakaoMap = (isCustomlevelControl = false) => {
 
       kakao.maps.event.addListener(marker, 'click', () => {
         // TODO: 모달 컴포넌트 생성되면 모달 컴포넌트 연결 [24.02.17]
+        handleMouseUp?.();
         console.log('번개 모각코 생성할 좌표', marker.getPosition());
       });
 

--- a/src/hooks/useCreateKakaoMap.ts
+++ b/src/hooks/useCreateKakaoMap.ts
@@ -31,7 +31,12 @@ const useCreateKakaoMap = (isCustomlevelControl = false) => {
       const imageSrc =
         markerSrc ?? 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_red.png';
       const imageSize = new kakao.maps.Size(markerSize?.width ?? 64, markerSize?.height ?? 69);
-      const imageOption = { offset: new kakao.maps.Point(27, 69) };
+      const imageOption = {
+        offset: new kakao.maps.Point(
+          markerSize?.width ? markerSize?.width / 2 : 32,
+          markerSize?.height ? markerSize?.height / 2 : 69 / 2,
+        ),
+      };
 
       const markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize, imageOption);
       const marker = new kakao.maps.Marker({
@@ -98,7 +103,6 @@ const useCreateKakaoMap = (isCustomlevelControl = false) => {
         };
 
         const createdMap = new window.kakao.maps.Map(mapRef.current, mapOption);
-        // TODO: 커스텀 컨트롤러 사용할지 논의 후 변경 [24.02.14]
         if (!isCustomlevelControl) {
           const zoomControl = new kakao.maps.ZoomControl();
           createdMap.addControl(zoomControl, kakao.maps.ControlPosition.TOPRIGHT);

--- a/src/hooks/useRenderMarkerByData.ts
+++ b/src/hooks/useRenderMarkerByData.ts
@@ -6,7 +6,10 @@ interface MakerInfo {
   data: MGCSummary;
 }
 
-const useRenderMarkerByData = (openBottomSheetAndUpdate: (mapData: MGCSummary[]) => void) => {
+const useRenderMarkerByData = (
+  openBottomSheetAndUpdate: (mapData: MGCSummary[]) => void,
+  handleMouseUp: () => void,
+) => {
   const setMarker = useCallback(
     (mapMGCData: MGCSummary[], clusterer: kakao.maps.MarkerClusterer) => {
       const markersInfo: MakerInfo[] = [];
@@ -27,6 +30,7 @@ const useRenderMarkerByData = (openBottomSheetAndUpdate: (mapData: MGCSummary[])
         });
 
         kakao.maps.event.addListener(marker, 'click', () => {
+          handleMouseUp();
           openBottomSheetAndUpdate([mgc]);
         });
 
@@ -37,7 +41,7 @@ const useRenderMarkerByData = (openBottomSheetAndUpdate: (mapData: MGCSummary[])
 
       return markersInfo;
     },
-    [openBottomSheetAndUpdate],
+    [handleMouseUp, openBottomSheetAndUpdate],
   );
 
   const renderMarker = (clusterer: kakao.maps.MarkerClusterer, mapMGCData: MGCSummary[]) => {

--- a/src/hooks/useRenderMarkerByData.ts
+++ b/src/hooks/useRenderMarkerByData.ts
@@ -17,7 +17,8 @@ const useRenderMarkerByData = (openBottomSheetAndUpdate: (mapData: MGCSummary[])
 
       clusterer?.clear();
 
-      for (const mgc of mapMGCData) {
+      for (let i = 0; i < mapMGCData.length; i++) {
+        const mgc = mapMGCData[i];
         if (!(mgc.location.latitude && mgc.location.longitude)) continue;
 
         const marker = new kakao.maps.Marker({
@@ -48,9 +49,11 @@ const useRenderMarkerByData = (openBottomSheetAndUpdate: (mapData: MGCSummary[])
       const markerList = [];
 
       for (const clusterMarker of clusterMarkers) {
-        markerList.push(
-          markersInfo.filter((markerInfo) => markerInfo.marker === clusterMarker)[0].data,
-        );
+        for (const markerInfo of markersInfo) {
+          if (markerInfo.marker === clusterMarker) {
+            markerList.push(markerInfo.data);
+          }
+        }
       }
 
       openBottomSheetAndUpdate(markerList);

--- a/src/hooks/useRenderMarkerByData.ts
+++ b/src/hooks/useRenderMarkerByData.ts
@@ -20,8 +20,7 @@ const useRenderMarkerByData = (
 
       clusterer?.clear();
 
-      for (let i = 0; i < mapMGCData.length; i++) {
-        const mgc = mapMGCData[i];
+      for (const mgc of mapMGCData) {
         if (!(mgc.location.latitude && mgc.location.longitude)) continue;
 
         const marker = new kakao.maps.Marker({


### PR DESCRIPTION
## 📝 주요 작업 내용
- 롱클릭시 마지막 클릭위치로 생성되는 문제 해결
  - 원인: 카카오맵에서 동작되지 않는 이벤트를 등록(mouseup, touchend) 및 이벤트 발생 순서 문제
  - 해결: 이벤트 변경
- 클러스터 클릭 시 오류 해결
  - 원인: 필터결과값이 undefined경우도 객체속성을 이용하려 해서 data가 없다는 오류 발생
  - 해결: 필터값 삽입 대신 if문으로 비교후 삽입으로 변경
- 마커클릭 시 마커위치에 위치표시 마커가 생성되는 버그 해결
  - 원인: 지도클릭 후 마커 클릭 이벤트가 발생해 map의 click이벤트가 일어나지 않음
  - 해결: 마커 클릭 이벤트 발생 시 clearTimeout

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷 스크린샷 (선택)
- 롱클릭
![롱클릭](https://github.com/jae-hun-e/LocoMoco/assets/66080362/8a0c94b3-a281-4204-bbf3-529d8b9158e8)
- 롱프레스
![롱프레스ㅡ](https://github.com/jae-hun-e/LocoMoco/assets/66080362/72d7d4bb-13ac-4aba-bacc-7a31e3074d26)

- 클러스터 클릭
![클러스터클릭_해결](https://github.com/jae-hun-e/LocoMoco/assets/66080362/ad38633e-541a-4a29-a736-eff8c7f064b2)

- 마커클릭
![GIF 2024-03-04 오전 10-54-03](https://github.com/jae-hun-e/LocoMoco/assets/66080362/bf8f84aa-4908-4036-9760-a94b0f4c5dfc)

## 💬 고민 중인 부분 및 참고사항 (선택)
- 버그 하나당  pr을 날리면 단위가 작은 거 같아서 묶어서 했습니다. 그런데 여러개를 묶는 것이 pr만 보고 확인하기 어려운거 같아 버그 하나당 1개씩 날리는 게 좋을지 고민입니다!! 여러분들은 어떤 게 더 좋으신가요??

close #47 

