### PR TITLE
[#52] 마이페이지 내부 모각코관련 세부페이지 UI 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# PWA
+sw.*
+workbox-*
+swe-worker-*
+firebasePrivateKey.json

--- a/src/app/_components/header/HeaderLeft.tsx
+++ b/src/app/_components/header/HeaderLeft.tsx
@@ -5,11 +5,11 @@ import { ChevronLeftIcon } from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
 
 const HeaderLeft = () => {
-  const pathname = usePathname().split('/')[1];
+  const pathname = usePathname().split('/').at(-1);
   const router = useRouter();
 
   // TODO: 에러 처리 중앙화 하기 [24/02/14]
-  if (!Object.keys(titleMap).includes(pathname)) throw new Error('잘못된 경로로 들어왔습니다.');
+  // if (!Object.keys(titleMap).includes(pathname)) throw new Error('잘못된 경로로 들어왔습니다.');
   const title = titleMap[pathname as keyof typeof titleMap];
 
   return (

--- a/src/app/mypage/(sub-page)/_components/MGCSummaryInfo.tsx
+++ b/src/app/mypage/(sub-page)/_components/MGCSummaryInfo.tsx
@@ -1,0 +1,39 @@
+import { ReactNode } from 'react';
+import MGCListItem from '@/app/_components/MGCList/MGCListItem';
+import ChattingButton from '@/app/mypage/(sub-page)/_components/button/ChattingButton';
+import LikeMGCAreaButtons from '@/app/mypage/(sub-page)/_components/button/LikeMGCAreaButtons';
+import ReviewButtons from '@/app/mypage/(sub-page)/_components/button/ReviewButtons';
+import { Separator } from '@/components/ui/separator';
+import { MGCSummary } from '@/types/MGCList';
+
+interface Props {
+  MGCInfo: MGCSummary;
+  readonly children?: ReactNode;
+}
+
+const MGCSummaryInfoContainer = ({ MGCInfo, children }: Props) => {
+  return (
+    <>
+      <MGCListItem
+        data={MGCInfo}
+        key={MGCInfo.id}
+      />
+      {children}
+      <Separator />
+    </>
+  );
+};
+
+interface ButtonProps {
+  MGCId: number;
+}
+const LikeMGCArea = (props: ButtonProps) => <LikeMGCAreaButtons {...props} />;
+const Chatting = (props: ButtonProps) => <ChattingButton {...props} />;
+const Reviews = (props: ButtonProps) => <ReviewButtons {...props} />;
+
+const MGCSummaryInfo = Object.assign(MGCSummaryInfoContainer, {
+  LikeMGCArea,
+  Chatting,
+  Reviews,
+});
+export default MGCSummaryInfo;

--- a/src/app/mypage/(sub-page)/_components/button/ChattingButton.tsx
+++ b/src/app/mypage/(sub-page)/_components/button/ChattingButton.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import MainStyleButton from '@/components/MainStyleButton';
+
+const ChattingButton = ({ MGCId }: { MGCId: number }) => {
+  // TODO: 채팅방으로 이동 [24/03/05]
+  const handleChattingLink = () => {
+    console.log('MGCId', MGCId);
+  };
+
+  return (
+    <MainStyleButton
+      content="채팅방으로 이동"
+      onClick={handleChattingLink}
+    />
+  );
+};
+
+export default ChattingButton;

--- a/src/app/mypage/(sub-page)/_components/button/LikeMGCAreaButtons.tsx
+++ b/src/app/mypage/(sub-page)/_components/button/LikeMGCAreaButtons.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import MainStyleButton from '@/components/MainStyleButton';
+
+const LikeMGCAreaButtons = ({ MGCId }: { MGCId: number }) => {
+  // TODO: 참여하기 API 실행 [24/03/05]
+  const handleParticipation = () => {
+    console.log('MGCId', MGCId);
+  };
+
+  const handleCancelLike = () => {
+    console.log('찜하기 취소 -> 낙관적업데이트하기');
+  };
+
+  return (
+    <div className="flex w-full gap-2">
+      <MainStyleButton
+        content="참여하기"
+        layout="flex-grow"
+        onClick={handleParticipation}
+      />
+      <MainStyleButton
+        content="찜하기 취소"
+        layout="flex-grow-0"
+        className="bg-layer-5 px-5pxr"
+        onClick={handleCancelLike}
+      />
+    </div>
+  );
+};
+
+export default LikeMGCAreaButtons;

--- a/src/app/mypage/(sub-page)/_components/button/ReviewButtons.tsx
+++ b/src/app/mypage/(sub-page)/_components/button/ReviewButtons.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import MainStyleButton from '@/components/MainStyleButton';
+
+const ReviewButtons = ({ MGCId }: { MGCId: number }) => {
+  // TODO: 각 리뷰창으로 이동 [24/03/05]
+  const handleReceivedReviewsLink = () => {
+    console.log('MGCId', MGCId);
+  };
+
+  const handleSendReviewsLink = () => {
+    console.log('MGCId', MGCId);
+  };
+
+  return (
+    <div className="flex w-full gap-2">
+      <MainStyleButton
+        content="받은 리뷰"
+        layout="flex-grow"
+        className="bg-layer-5"
+        onClick={handleReceivedReviewsLink}
+      />
+      <MainStyleButton
+        content="보낸 리뷰"
+        layout="flex-grow"
+        className="bg-layer-5"
+        onClick={handleSendReviewsLink}
+      />
+    </div>
+  );
+};
+
+export default ReviewButtons;

--- a/src/app/mypage/(sub-page)/current-join-mgc/page.tsx
+++ b/src/app/mypage/(sub-page)/current-join-mgc/page.tsx
@@ -1,0 +1,22 @@
+import MGCSummaryInfo from '@/app/mypage/(sub-page)/_components/MGCSummaryInfo';
+import { dummyData } from '@/constants/mgcListDummy';
+
+const CurrentMGC = () => {
+  // TODO: API 연동 후 실데이터로 변경 [24/03/05]
+  const currentMGCData = dummyData;
+
+  return (
+    <>
+      {currentMGCData.map((mgc) => (
+        <MGCSummaryInfo
+          MGCInfo={mgc}
+          key={mgc.id}
+        >
+          <MGCSummaryInfo.Chatting MGCId={mgc.id} />
+        </MGCSummaryInfo>
+      ))}
+    </>
+  );
+};
+
+export default CurrentMGC;

--- a/src/app/mypage/(sub-page)/end-join-mgc/page.tsx
+++ b/src/app/mypage/(sub-page)/end-join-mgc/page.tsx
@@ -1,0 +1,22 @@
+import MGCSummaryInfo from '@/app/mypage/(sub-page)/_components/MGCSummaryInfo';
+import { dummyData } from '@/constants/mgcListDummy';
+
+const EndMGC = () => {
+  // TODO: API 연동 후 실데이터로 변경 [24/03/05]
+  const endMGCData = dummyData;
+
+  return (
+    <>
+      {endMGCData.map((mgc) => (
+        <MGCSummaryInfo
+          MGCInfo={mgc}
+          key={mgc.id}
+        >
+          <MGCSummaryInfo.Reviews MGCId={mgc.id} />
+        </MGCSummaryInfo>
+      ))}
+    </>
+  );
+};
+
+export default EndMGC;

--- a/src/app/mypage/(sub-page)/layout.tsx
+++ b/src/app/mypage/(sub-page)/layout.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+import Header from '@/app/_components/header/Header';
+
+interface Props {
+  readonly children: ReactNode;
+}
+const SubPage = ({ children }: Props) => {
+  return (
+    <>
+      <Header />
+      {children}
+    </>
+  );
+};
+
+export default SubPage;

--- a/src/app/mypage/(sub-page)/like-mgc/page.tsx
+++ b/src/app/mypage/(sub-page)/like-mgc/page.tsx
@@ -1,0 +1,22 @@
+import MGCSummaryInfo from '@/app/mypage/(sub-page)/_components/MGCSummaryInfo';
+import { dummyData } from '@/constants/mgcListDummy';
+
+const LikeMGC = () => {
+  // TODO: API 연동 후 실데이터로 변경 [24/03/05]
+  const likeMGCData = dummyData;
+
+  return (
+    <>
+      {likeMGCData.map((mgc) => (
+        <MGCSummaryInfo
+          MGCInfo={mgc}
+          key={mgc.id}
+        >
+          <MGCSummaryInfo.LikeMGCArea MGCId={mgc.id} />
+        </MGCSummaryInfo>
+      ))}
+    </>
+  );
+};
+
+export default LikeMGC;

--- a/src/app/mypage/current-join-mgc/page.tsx
+++ b/src/app/mypage/current-join-mgc/page.tsx
@@ -1,5 +1,0 @@
-const CurrentMGC = () => {
-  return <div>currentMGC</div>;
-};
-
-export default CurrentMGC;

--- a/src/app/mypage/end-join-mgc/page.tsx
+++ b/src/app/mypage/end-join-mgc/page.tsx
@@ -1,5 +1,0 @@
-const EndMGC = () => {
-  return <div>end MGC</div>;
-};
-
-export default EndMGC;

--- a/src/app/mypage/like-mgc/page.tsx
+++ b/src/app/mypage/like-mgc/page.tsx
@@ -1,5 +1,0 @@
-const LikeMGC = () => {
-  return <div>like MGC</div>;
-};
-
-export default LikeMGC;

--- a/src/constants/routeURL.ts
+++ b/src/constants/routeURL.ts
@@ -21,4 +21,7 @@ export const titleMap = {
   chat: '채팅',
   create: '모각코 생성',
   mgc: '모각코 디테일',
+  'current-join-mgc': '참여중인 모각코',
+  'end-join-mgc': '종료된 모각코',
+  'like-mgc': '내가 찜한 모각코',
 } as const;


### PR DESCRIPTION
## 📝 주요 작업 내용

- 마이페이지 내에 모각코 페이지들이 비슷한 속성을 가지고 있어서 합성컴포넌트로 구현했습니다.
- 내부에 공유하는 상태값이 있을 것이라 예상했지만 없었어서 아쉽게 context로 상태를 공유하는 로직은 없습니다. 
- summary 부분이 공통으로 들어가고 각 페이지 특성에 맞게 추가 버튼을 합성하였습니다. 


## 📷 스크린샷

내가 찜한 모각코
![image](https://github.com/jae-hun-e/LocoMoco/assets/76520477/a945bba5-e79c-4527-a6a5-345c38b99962)

참여중인 모각코
![image](https://github.com/jae-hun-e/LocoMoco/assets/76520477/97d0219e-d1d6-4e46-83a8-df31c69cd17f)

종료된 모각코
![image](https://github.com/jae-hun-e/LocoMoco/assets/76520477/540c0e1e-26e5-4374-95a3-77d0b78554ea)


## 💬 고민 중인 부분 및 참고사항 (선택)

### 고민 중...
찜하기 부분에서 찜 취소를 버튼 vs 하트모양 으로할지 고민입니다.
1. 버튼 -> 안 이쁜데 한 번 더 생각하게 됨
2. 하트모양 -> 이쁜데 취소누르기 너무 쉬워보임

그리고 찜 취소 후 모각코 리스트를 낙관적 업데이트 할지도 고민입니다. 뭔가 취소눌렀다가 다시 찜하는 사람도 있을 것 같아서,,, 

### 참고사항 
- 합성된 부분에 필요한게 MGC id라고 생각했는데 이것은 실제 API 연결 이후 변경될 수 있습니다. 

close #52

