### PR TITLE
[#63] 보낸리뷰, 받은리뷰 페이지 ui 구현

### DIFF
--- a/src/app/_components/reviewList/ReviewDetail.tsx
+++ b/src/app/_components/reviewList/ReviewDetail.tsx
@@ -1,0 +1,65 @@
+import { ReviewDetailType } from '@/types/review';
+import { X } from 'lucide-react';
+
+interface ReviewDetailProps {
+  title: string;
+  reviewDetailData?: ReviewDetailType;
+  onClose: () => void;
+}
+
+const ReviewDetail = ({ title, reviewDetailData, onClose }: ReviewDetailProps) => {
+  const dummyReviewContentId = [
+    {
+      reviewContentId: 1,
+      content: '친절하고 매너있어요',
+    },
+    {
+      reviewContentId: 2,
+      content: '시간약속을 잘 지켜요',
+    },
+    {
+      reviewContentId: 3,
+      content: '응답이 빨라요',
+    },
+    {
+      reviewContentId: 4,
+      content: '좋은 점4',
+    },
+  ];
+
+  return (
+    <div className="px-10pxr py-15pxr">
+      <div className="mb-20pxr flex items-center">
+        <button onClick={onClose}>
+          <X
+            width={20}
+            height={20}
+          />
+        </button>
+        <p className="grow text-center font-bold">내가 {title} 후기</p>
+      </div>
+      <p className="mb-10pxr text-lg font-bold">{reviewDetailData?.nickname}님과 만남의 후기에요</p>
+      <ul>
+        <p className="mb-5pxr text-sm font-bold">느낀점</p>
+        {reviewDetailData?.reviewContentId.map((id) => (
+          <li
+            key={id}
+            className="text-sm"
+          >
+            {dummyReviewContentId.find(({ reviewContentId }) => reviewContentId === id)?.content}
+          </li>
+        ))}
+      </ul>
+      {reviewDetailData?.content ? (
+        <div className="mt-25pxr text-sm">
+          <p className="mb-5pxr font-bold">후기</p>
+          <div className="max-h-200pxr overflow-auto rounded bg-main-5 p-10pxr scrollbar-hide">
+            <p className="text-sm">{reviewDetailData?.content}</p>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default ReviewDetail;

--- a/src/app/_components/reviewList/ReviewItem.tsx
+++ b/src/app/_components/reviewList/ReviewItem.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import React from 'react';
+import { Separator } from '@/components/ui/separator';
+import UserInfo from './UserInfo';
+
+export interface UserInfoData {
+  userId: number;
+  nickname: string;
+  job: string;
+  profileImage: {
+    imageId: number;
+    path: string;
+  };
+  score: number;
+  createdAt: string;
+}
+
+interface ReviewData extends UserInfoData {
+  reviewId: number;
+  reviewContentId: number[];
+  content: string;
+}
+
+const ReviewItem = ({ data }: { data: ReviewData }) => {
+  const { content, reviewContentId, reviewId, ...userInfo } = data;
+
+  const handleRevieItemClick = () => {
+    console.log(reviewId);
+    // reviewContentId 링크 이동 시 넘겨주기 or reviewId로만 조회되는 api 요청하기
+    console.log(reviewContentId);
+  };
+
+  return (
+    <div onClick={handleRevieItemClick}>
+      <div className="py-10pxr">
+        <UserInfo userInfo={userInfo} />
+        <p className="mt-20pxr text-sm">
+          {content === '' ? '작성한 상세 리뷰가 없습니다.' : content}
+        </p>
+      </div>
+      <Separator></Separator>
+    </div>
+  );
+};
+
+export default ReviewItem;

--- a/src/app/_components/reviewList/ReviewItem.tsx
+++ b/src/app/_components/reviewList/ReviewItem.tsx
@@ -1,8 +1,12 @@
-'use client';
-
 import React from 'react';
 import { Separator } from '@/components/ui/separator';
+import { ReviewDetailType } from '@/types/review';
 import UserInfo from './UserInfo';
+
+interface ReviewItemProps {
+  data: ReviewData;
+  onClick: (detailData: ReviewDetailType) => void;
+}
 
 export interface UserInfoData {
   userId: number;
@@ -22,20 +26,22 @@ interface ReviewData extends UserInfoData {
   content: string;
 }
 
-const ReviewItem = ({ data }: { data: ReviewData }) => {
-  const { content, reviewContentId, reviewId, ...userInfo } = data;
+const ReviewItem = ({ data, onClick }: ReviewItemProps) => {
+  const { content, reviewContentId, ...userInfo } = data;
 
   const handleRevieItemClick = () => {
-    console.log(reviewId);
-    // reviewContentId 링크 이동 시 넘겨주기 or reviewId로만 조회되는 api 요청하기
-    console.log(reviewContentId);
+    onClick({
+      reviewContentId,
+      content: content,
+      nickname: userInfo.nickname,
+    });
   };
 
   return (
     <div onClick={handleRevieItemClick}>
       <div className="py-10pxr">
         <UserInfo userInfo={userInfo} />
-        <p className="mt-20pxr text-sm">
+        <p className="mt-20pxr text-sm max-two-lines">
           {content === '' ? '작성한 상세 리뷰가 없습니다.' : content}
         </p>
       </div>

--- a/src/app/_components/reviewList/ReviewList.tsx
+++ b/src/app/_components/reviewList/ReviewList.tsx
@@ -1,3 +1,10 @@
+'use client';
+
+import { useState } from 'react';
+import { useThunderModalStore } from '@/store/thunderModalStore';
+import { ReviewDetailType } from '@/types/review';
+import Modal from '../Modal';
+import ReviewDetail from './ReviewDetail';
 import ReviewItem from './ReviewItem';
 
 export interface ReviewData {
@@ -17,22 +24,47 @@ export interface ReviewData {
 
 interface ReviewListProps {
   title: string;
-  Reviews: ReviewData[];
+  reviews: ReviewData[];
 }
 
-const ReviewList = ({ title, Reviews }: ReviewListProps) => {
+const ReviewList = ({ title, reviews }: ReviewListProps) => {
+  const { isOpen, toggleModal } = useThunderModalStore();
+  const [reviewDetailData, setReviewDetailData] = useState<ReviewDetailType>();
+
+  const handleReviewClick = (detailData: ReviewDetailType) => {
+    setReviewDetailData(detailData);
+    toggleModal();
+  };
+
+  const handleCloseModal = () => {
+    toggleModal();
+  };
+
   return (
-    <div>
-      <p className="mb-5pxr font-bold">
-        {title} {Reviews.length}개
-      </p>
-      {Reviews.map((review) => (
-        <ReviewItem
-          key={review.reviewId}
-          data={review}
+    <>
+      <div>
+        <p className="mb-5pxr font-bold">
+          {title} 후기 {reviews.length}개
+        </p>
+        {reviews.map((review) => (
+          <ReviewItem
+            onClick={handleReviewClick}
+            key={review.reviewId}
+            data={review}
+          />
+        ))}
+      </div>
+      <Modal
+        isOpen={isOpen}
+        onClose={handleCloseModal}
+      >
+        <ReviewDetail
+          onClose={handleCloseModal}
+          title={title}
+          reviewDetailData={reviewDetailData}
         />
-      ))}
-    </div>
+      </Modal>
+    </>
   );
 };
 

--- a/src/app/_components/reviewList/ReviewList.tsx
+++ b/src/app/_components/reviewList/ReviewList.tsx
@@ -1,0 +1,39 @@
+import ReviewItem from './ReviewItem';
+
+export interface ReviewData {
+  reviewId: number;
+  reviewContentId: number[];
+  content: string;
+  userId: number;
+  nickname: string;
+  job: string;
+  profileImage: {
+    imageId: number;
+    path: string;
+  };
+  score: number;
+  createdAt: string;
+}
+
+interface ReviewListProps {
+  title: string;
+  Reviews: ReviewData[];
+}
+
+const ReviewList = ({ title, Reviews }: ReviewListProps) => {
+  return (
+    <div>
+      <p className="mb-5pxr font-bold">
+        {title} {Reviews.length}개
+      </p>
+      {Reviews.map((review) => (
+        <ReviewItem
+          key={review.reviewId}
+          data={review}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default ReviewList;

--- a/src/app/_components/reviewList/UserInfo.tsx
+++ b/src/app/_components/reviewList/UserInfo.tsx
@@ -1,0 +1,58 @@
+import StarList from '@/app/chat/_components/review/StarList';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { formatDistance } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import Image from 'next/image';
+import { UserInfoData } from './ReviewItem';
+
+const UserInfo = ({ userInfo }: { userInfo: UserInfoData }) => {
+  return (
+    <>
+      <section className="my-10pxr">
+        <div className="flex items-center gap-2">
+          <Avatar className="h-32pxr w-32pxr rounded-full ">
+            <AvatarImage
+              src={userInfo.profileImage.path || 'https://github.com/shadcn.png'}
+              alt="유저 이미지"
+            />
+            <AvatarFallback>
+              <Image
+                src={'/oh.png'}
+                alt={'cn'}
+                width={32}
+                height={32}
+              />
+            </AvatarFallback>
+          </Avatar>
+          <div className="flex flex-col gap-3pxr">
+            <span className="mr-10pxr text-xs">{userInfo.nickname}</span>
+            <div className="flex items-center gap-2">
+              <div className="flex">
+                <StarList
+                  rating={userInfo.score}
+                  fisrtNumber={1}
+                  color="#58C694"
+                  size={15}
+                />
+                <StarList
+                  rating={5 - userInfo.score}
+                  fisrtNumber={userInfo.score + 1}
+                  color="#D9D9D9"
+                  size={15}
+                />
+              </div>
+              <span className="text-xs text-layer-6">
+                {formatDistance(new Date(userInfo.createdAt), new Date(), {
+                  addSuffix: true,
+                  locale: ko,
+                })}
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+};
+
+export default UserInfo;

--- a/src/app/chat/_components/review/StarList.tsx
+++ b/src/app/chat/_components/review/StarList.tsx
@@ -4,10 +4,11 @@ interface StarListProps {
   rating: number;
   fisrtNumber: number;
   color: string;
-  onClick: (rating: number) => void;
+  onClick?: (rating: number) => void;
+  size?: number;
 }
 
-const StarList = ({ rating, fisrtNumber, color, onClick }: StarListProps) => {
+const StarList = ({ rating, fisrtNumber, color, onClick, size }: StarListProps) => {
   const getArrayFromCount = (count: number, fisrtNumber: number) => {
     const array = Array.from({ length: count }, (_, index) => index + fisrtNumber);
 
@@ -20,11 +21,11 @@ const StarList = ({ rating, fisrtNumber, color, onClick }: StarListProps) => {
         <button
           id={`${number}`}
           key={number}
-          onClick={() => onClick(number)}
+          onClick={() => onClick?.(number)}
         >
           <Star
-            width={40}
-            height={40}
+            width={size ?? 40}
+            height={size ?? 40}
             stroke="transparent"
             fill={color}
           />

--- a/src/app/mypage/end-join-mgc/received-reviews/page.tsx
+++ b/src/app/mypage/end-join-mgc/received-reviews/page.tsx
@@ -1,0 +1,47 @@
+import ReviewList from '@/app/_components/reviewList/ReviewList';
+
+const ReceivedReviews = () => {
+  const dummy = [
+    {
+      reviewId: 1,
+      reviewerId: 5,
+      score: 4,
+      reviewContentId: [1, 2, 3],
+      content: '좋았습니다~',
+      userId: 1,
+      nickname: '닉네임',
+      job: '현직자',
+      profileImage: {
+        imageId: 1,
+        path: '',
+      },
+      createdAt: '2024-02-12',
+    },
+    {
+      reviewId: 2,
+      reviewerId: 5,
+      score: 3,
+      reviewContentId: [1, 2, 3],
+      content: '',
+      userId: 1,
+      nickname: '닉네임2',
+      job: '현직자',
+      profileImage: {
+        imageId: 1,
+        path: '',
+      },
+      createdAt: '2024-03-06',
+    },
+  ];
+
+  return (
+    <>
+      <ReviewList
+        reviews={dummy}
+        title="보낸"
+      />
+    </>
+  );
+};
+
+export default ReceivedReviews;

--- a/src/app/mypage/end-join-mgc/send-reviews/page.tsx
+++ b/src/app/mypage/end-join-mgc/send-reviews/page.tsx
@@ -1,0 +1,63 @@
+import ReviewList from '@/app/_components/reviewList/ReviewList';
+
+const SendReviews = () => {
+  const dummy = [
+    {
+      reviewId: 1,
+      reviewerId: 5,
+      score: 4,
+      reviewContentId: [1, 2, 3],
+      content:
+        'It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that ',
+      userId: 1,
+      nickname: '닉네임',
+      job: '현직자',
+      profileImage: {
+        imageId: 1,
+        path: '',
+      },
+      createdAt: '2024-02-12',
+    },
+    {
+      reviewId: 2,
+      reviewerId: 5,
+      score: 3,
+      reviewContentId: [1, 2, 3, 4],
+      content: '',
+      userId: 1,
+      nickname: '닉네임2',
+      job: '현직자',
+      profileImage: {
+        imageId: 1,
+        path: '',
+      },
+      createdAt: '2024-03-06',
+    },
+    {
+      reviewId: 3,
+      reviewerId: 5,
+      score: 3,
+      reviewContentId: [1, 4],
+      content: '',
+      userId: 1,
+      nickname: '닉네임3',
+      job: '현직자',
+      profileImage: {
+        imageId: 1,
+        path: '',
+      },
+      createdAt: '2024-03-06',
+    },
+  ];
+
+  return (
+    <>
+      <ReviewList
+        reviews={dummy}
+        title="받은"
+      />
+    </>
+  );
+};
+
+export default SendReviews;

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -1,0 +1,5 @@
+export interface ReviewDetailType {
+  reviewContentId: number[];
+  content: string;
+  nickname: string;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -86,7 +86,8 @@ const config = {
         'main-2': '#85D5B1',
         'main-3': '#A4E0C5',
         'main-4': '#C2EAD8',
-        'main-5': '#F0FAF5',
+        'main-5': '#E0F6EB',
+        'main-6': '#F0FAF5',
         hover: '#39A776',
 
         'red-1': '#FF5A5A',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -126,6 +126,13 @@ const config = {
             display: 'none',
           },
         },
+        '.max-two-lines': {
+          'text-overflow': 'ellipsis',
+          overflow: 'hidden',
+          display: '-webkit-box',
+          '-webkit-box-orient': 'vertical',
+          '-webkit-line-clamp': '2',
+        },
       });
     }),
   ],


### PR DESCRIPTION
## 📝 주요 작업 내용
- 두페이지 공통 컴포넌트 제작
- 각 페이지 ui 구현
- 리뷰 클릭시 해당 리뷰 내용을 모달에 표시

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
## 📷 스크린샷 (선택)
디자인적으로 수정할 게 있다면 언제든 말씀해주세요~~!!
- 리뷰 페이지
<img src="https://github.com/jae-hun-e/LocoMoco/assets/66080362/b1aad3ce-f883-43ed-9e73-00b927c87185" width="300" height="533" />

- 리뷰 클릭 시 모달 켜진 화면

<img src="https://github.com/jae-hun-e/LocoMoco/assets/66080362/6f5305dc-c491-4b42-bb1f-6320ac6d62b0" width="300" height="533" />

## 💬 고민 중인 부분 및 참고사항 (선택)

### 참고
- 색상 변수 main-4와 main-5 사이의 색상이 필요해서 추가했습니다! 원래 main-5였던 색상은 main-6으로 수정했습니다.
- 헤더는 재훈님의 pr 내용처럼 mypage/(sub_page)/layout.tsx에 추가할지, 각 페이지의 layout.tsx에 추가할지 정한 후 추가하겠습니다!
- 프로필 부분 ui가 유사한 게 많아서 추후에 합성컴포넌트로 리팩토링 하겠습니다!
![image](https://github.com/jae-hun-e/LocoMoco/assets/66080362/4d1ac7d9-7733-4ae1-b552-f69d834d0f54)


### 고민

- 헤더를 mypage/(sub_page)/layout.tsx에 추가하는 법, 각 페이지의 layout.tsx에 추가하는 법 어떤 게 더 좋을까요??
- 이런식으로 화면을 다 채우는 모달도 괜찮을 거 같은데 팀원분들은 어떤 게 더 좋을거 같은지 궁금합니다!!
<img src="https://github.com/jae-hun-e/LocoMoco/assets/66080362/569e0aa4-9e15-4025-b11e-e002735fa847" width="300" height="533" />


close #63

