### PR TITLE
[#68] 로그인/회원가입 로직 변경

### DIFF
--- a/src/apis/core.ts
+++ b/src/apis/core.ts
@@ -23,7 +23,7 @@ axiosInstance.interceptors.request.use(
     }
 
     if (typeof window !== 'undefined') {
-      const token = getItem<string | undefined>(localStorage, 'token');
+      const token = getItem<string>(localStorage, 'token');
       if (token) config.headers['Authorization'] = `Bearer ${token}`;
     }
     return config;

--- a/src/apis/core.ts
+++ b/src/apis/core.ts
@@ -24,7 +24,7 @@ axiosInstance.interceptors.request.use(
 
     if (typeof window !== 'undefined') {
       const token = getItem<string | undefined>(localStorage, 'token');
-      if (token) config.headers['Authorization'] = token;
+      if (token) config.headers['Authorization'] = `Bearer ${token}`;
     }
     return config;
   },

--- a/src/apis/core.ts
+++ b/src/apis/core.ts
@@ -24,7 +24,7 @@ axiosInstance.interceptors.request.use(
 
     if (typeof window !== 'undefined') {
       const token = localStorage.getItem('token');
-      if (token) config.headers['Authorization'] = `Bearer ${token}`;
+      if (token) config.headers['Authorization'] = token;
     }
     return config;
   },

--- a/src/apis/core.ts
+++ b/src/apis/core.ts
@@ -1,3 +1,4 @@
+import { getItem } from '@/utils/storage';
 import axios, { AxiosInstance, AxiosRequestConfig, Method } from 'axios';
 import qs from 'qs';
 
@@ -7,7 +8,6 @@ const axiosInstance: AxiosInstance = axios.create({
   headers: { 'Content-Type': 'application/json' },
 });
 
-// todo: token 관련 처리는 추후 추가해야함 [24/02/07]
 axiosInstance.interceptors.request.use(
   (config) => {
     if (config.params) {
@@ -23,7 +23,7 @@ axiosInstance.interceptors.request.use(
     }
 
     if (typeof window !== 'undefined') {
-      const token = localStorage.getItem('token');
+      const token = getItem<string | undefined>(localStorage, 'token');
       if (token) config.headers['Authorization'] = token;
     }
     return config;

--- a/src/app/(auth)/redirect/[method]/page.tsx
+++ b/src/app/(auth)/redirect/[method]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import client from '@/apis/core';
+import { clearItem, getItem, setItem } from '@/utils/storage';
 import { useRouter, useSearchParams } from 'next/navigation';
 import ProgressBar from '../../signup/_components/ProgressBar';
 
@@ -31,11 +32,9 @@ const Redirect = ({ params: { method } }: { params: { method: string } }) => {
   const router = useRouter();
 
   useEffect(() => {
-    const kakaoToken = localStorage.getItem('kakao_token');
-    const githubToken = localStorage.getItem('github_token');
-    if (kakaoToken || githubToken) {
+    if (getItem(localStorage, 'token')) {
       alert('잘못된 접근입니다. 홈으로 돌아갑니다');
-      sessionStorage.clear();
+      clearItem(sessionStorage);
       router.replace('/');
     }
   }, [router]);
@@ -47,14 +46,14 @@ const Redirect = ({ params: { method } }: { params: { method: string } }) => {
       })
       .then(({ tokenResponseDto: { access_token }, userInfoDto: { nickname, userId } }) => {
         if (!nickname) {
-          sessionStorage.setItem('token', access_token);
-          sessionStorage.setItem(`userId`, userId.toString());
+          setItem(sessionStorage, 'token', access_token);
+          setItem(sessionStorage, 'userId', userId.toString());
+
           router.replace(`/signup/${method}`);
         } else {
-          localStorage.setItem('token', access_token);
-          localStorage.setItem(`userId`, userId.toString());
-          localStorage.setItem('provider', method.toUpperCase());
-          console.log(method.toUpperCase());
+          setItem(localStorage, 'token', access_token);
+          setItem(localStorage, `userId`, userId.toString());
+          setItem(localStorage, 'provider', method.toUpperCase());
           router.replace('/');
         }
       });

--- a/src/app/(auth)/redirect/[method]/page.tsx
+++ b/src/app/(auth)/redirect/[method]/page.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useEffect } from 'react';
+import client from '@/apis/core';
+import { useRouter, useSearchParams } from 'next/navigation';
+import ProgressBar from '../../signup/_components/ProgressBar';
+
+interface ResponseType {
+  isNewUser: boolean;
+  tokenResponseDto: {
+    token_type: string;
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+    refresh_token_expires_in: number;
+  };
+  userInfoDto: {
+    birth: null | string;
+    email: string;
+    gender: null | 'male' | 'female';
+    job: null | 'worker' | 'ready' | 'etc';
+    nickname: null | string;
+    provider: 'Github' | 'Kakao';
+    temperature: number;
+    userId: number;
+  };
+}
+
+const Redirect = ({ params: { method } }: { params: { method: string } }) => {
+  const code = useSearchParams().get('code');
+  const router = useRouter();
+
+  useEffect(() => {
+    const kakaoToken = localStorage.getItem('kakao_token');
+    const githubToken = localStorage.getItem('github_token');
+    if (kakaoToken || githubToken) {
+      alert('잘못된 접근입니다. 홈으로 돌아갑니다');
+      sessionStorage.clear();
+      router.replace('/');
+    }
+  }, [router]);
+
+  useEffect(() => {
+    client
+      .get<ResponseType>({
+        url: `users/login/${method}/callback?code=${code}`,
+      })
+      .then(({ tokenResponseDto: { access_token }, userInfoDto: { nickname, userId } }) => {
+        if (!nickname) {
+          sessionStorage.setItem(`${method}_token`, access_token);
+          sessionStorage.setItem(`userId`, userId.toString());
+          router.replace(`/signup/${method}`);
+        } else {
+          localStorage.setItem(`${method}_token`, access_token);
+          localStorage.setItem(`userId`, userId.toString());
+          router.replace('/');
+        }
+      });
+  }, [code, method, router]);
+
+  return (
+    <div className="flex h-svh flex-col justify-center">
+      <p className="">Redirecting...</p>
+      <ProgressBar />
+    </div>
+  );
+};
+
+export default Redirect;

--- a/src/app/(auth)/redirect/[method]/page.tsx
+++ b/src/app/(auth)/redirect/[method]/page.tsx
@@ -53,6 +53,8 @@ const Redirect = ({ params: { method } }: { params: { method: string } }) => {
         } else {
           localStorage.setItem(`${method}_token`, access_token);
           localStorage.setItem(`userId`, userId.toString());
+          localStorage.setItem('provider', method.toUpperCase());
+          console.log(method.toUpperCase());
           router.replace('/');
         }
       });

--- a/src/app/(auth)/redirect/[method]/page.tsx
+++ b/src/app/(auth)/redirect/[method]/page.tsx
@@ -47,11 +47,11 @@ const Redirect = ({ params: { method } }: { params: { method: string } }) => {
       })
       .then(({ tokenResponseDto: { access_token }, userInfoDto: { nickname, userId } }) => {
         if (!nickname) {
-          sessionStorage.setItem(`${method}_token`, access_token);
+          sessionStorage.setItem('token', access_token);
           sessionStorage.setItem(`userId`, userId.toString());
           router.replace(`/signup/${method}`);
         } else {
-          localStorage.setItem(`${method}_token`, access_token);
+          localStorage.setItem('token', access_token);
           localStorage.setItem(`userId`, userId.toString());
           localStorage.setItem('provider', method.toUpperCase());
           console.log(method.toUpperCase());

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -1,11 +1,25 @@
 'use client';
 
+import { useEffect } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 const Signin = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    const kakaoToken = localStorage.getItem('kakao_token');
+    const githubToken = localStorage.getItem('github_token');
+    if (kakaoToken || githubToken) {
+      alert('잘못된 접근입니다. 홈으로 돌아갑니다');
+      sessionStorage.clear();
+      router.replace('/');
+    }
+  }, [router]);
+
   return (
-    <section className="mx-auto flex h-full flex-col items-center justify-center gap-3">
+    <section className="mx-auto flex h-svh flex-col items-center justify-center gap-3">
       <div className="mb-5 text-3xl font-bold">LocoMoco</div>
       <Link
         href={`https://github.com/login/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID}`}
@@ -22,7 +36,7 @@ const Signin = () => {
       </Link>
 
       <Link
-        href={`https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID}&redirect_uri=http://localhost:3000/signup/kakao&response_type=code`}
+        href={`https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID}&redirect_uri=http://localhost:3000/redirect/kakao&response_type=code`}
       >
         <button className="flex h-50pxr w-240pxr items-center justify-center gap-8 rounded-sm bg-[#fdd801] opacity-70 hover:opacity-100">
           <Image

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { clearItem, getItem } from '@/utils/storage';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -9,11 +10,9 @@ const Signin = () => {
   const router = useRouter();
 
   useEffect(() => {
-    const kakaoToken = localStorage.getItem('kakao_token');
-    const githubToken = localStorage.getItem('github_token');
-    if (kakaoToken || githubToken) {
+    if (getItem(localStorage, 'token')) {
       alert('잘못된 접근입니다. 홈으로 돌아갑니다');
-      sessionStorage.clear();
+      clearItem(sessionStorage);
       router.replace('/');
     }
   }, [router]);

--- a/src/app/(auth)/signup/[method]/page.tsx
+++ b/src/app/(auth)/signup/[method]/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import client from '@/apis/core';
 import { Button } from '@/components/ui/button';
+import { clearItem, getItem, setItem } from '@/utils/storage';
 import { useRouter } from 'next/navigation';
 import DatePick from '../_components/DatePick';
 import Gender from '../_components/Gender';
@@ -40,18 +41,18 @@ const Signup = ({ params: { method } }: { params: { method: string } }) => {
   const router = useRouter();
 
   useEffect(() => {
-    const token = localStorage.getItem('token');
+    const token = getItem(localStorage, 'token');
     if (token) {
       alert('잘못된 접근입니다. 홈으로 돌아갑니다');
-      sessionStorage.clear();
+      clearItem(sessionStorage);
       router.replace('/');
     }
     addEventListener('beforeunload', () => {
-      sessionStorage.clear();
+      clearItem(sessionStorage);
     });
     return () =>
       removeEventListener('beforeunload', () => {
-        sessionStorage.clear();
+        clearItem(sessionStorage);
       });
   }, [router]);
 
@@ -62,8 +63,8 @@ const Signup = ({ params: { method } }: { params: { method: string } }) => {
       alert('닉네임 중복체크를 해주세요');
       return;
     }
-    const token = sessionStorage.getItem(`token`);
-    const userId = sessionStorage.getItem('userId');
+    const token = getItem<string | undefined>(sessionStorage, `token`);
+    const userId = getItem<string | undefined>(sessionStorage, 'userId');
     if (!token || !userId) return;
     client
       .put({
@@ -80,10 +81,10 @@ const Signup = ({ params: { method } }: { params: { method: string } }) => {
       })
       .then(() => {
         alert('회원가입 성공');
-        localStorage.setItem('token', token);
-        localStorage.setItem('userId', userId);
-        localStorage.setItem('provider', method.toUpperCase());
-        sessionStorage.clear();
+        setItem(localStorage, 'token', token);
+        setItem(localStorage, 'userId', userId);
+        setItem(localStorage, 'provider', method.toUpperCase());
+        clearItem(sessionStorage);
         router.replace('/');
       })
       .catch((error) => alert(error));

--- a/src/app/(auth)/signup/[method]/page.tsx
+++ b/src/app/(auth)/signup/[method]/page.tsx
@@ -40,9 +40,8 @@ const Signup = ({ params: { method } }: { params: { method: string } }) => {
   const router = useRouter();
 
   useEffect(() => {
-    const kakaoToken = localStorage.getItem('kakao_token');
-    const githubToken = localStorage.getItem('github_token');
-    if (kakaoToken || githubToken) {
+    const token = localStorage.getItem('token');
+    if (token) {
       alert('잘못된 접근입니다. 홈으로 돌아갑니다');
       sessionStorage.clear();
       router.replace('/');
@@ -63,14 +62,14 @@ const Signup = ({ params: { method } }: { params: { method: string } }) => {
       alert('닉네임 중복체크를 해주세요');
       return;
     }
-    const token = sessionStorage.getItem(`${method}_token`);
+    const token = sessionStorage.getItem(`token`);
     const userId = sessionStorage.getItem('userId');
     if (!token || !userId) return;
     client
       .put({
         url: `/users/init/${userId}`,
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: token,
         },
         data: {
           nickname: getValues('nickname'),
@@ -81,7 +80,7 @@ const Signup = ({ params: { method } }: { params: { method: string } }) => {
       })
       .then(() => {
         alert('회원가입 성공');
-        localStorage.setItem(`${method}_token`, token);
+        localStorage.setItem('token', token);
         localStorage.setItem('userId', userId);
         localStorage.setItem('provider', method.toUpperCase());
         sessionStorage.clear();

--- a/src/app/(auth)/signup/[method]/page.tsx
+++ b/src/app/(auth)/signup/[method]/page.tsx
@@ -47,6 +47,13 @@ const Signup = ({ params: { method } }: { params: { method: string } }) => {
       sessionStorage.clear();
       router.replace('/');
     }
+    addEventListener('beforeunload', () => {
+      sessionStorage.clear();
+    });
+    return () =>
+      removeEventListener('beforeunload', () => {
+        sessionStorage.clear();
+      });
   }, [router]);
 
   const onSubmit = useCallback(async () => {

--- a/src/app/(auth)/signup/[method]/page.tsx
+++ b/src/app/(auth)/signup/[method]/page.tsx
@@ -83,6 +83,7 @@ const Signup = ({ params: { method } }: { params: { method: string } }) => {
         alert('회원가입 성공');
         localStorage.setItem(`${method}_token`, token);
         localStorage.setItem('userId', userId);
+        localStorage.setItem('provider', method.toUpperCase());
         sessionStorage.clear();
         router.replace('/');
       })

--- a/src/app/(auth)/signup/[method]/page.tsx
+++ b/src/app/(auth)/signup/[method]/page.tsx
@@ -69,9 +69,6 @@ const Signup = ({ params: { method } }: { params: { method: string } }) => {
     client
       .put({
         url: `/users/init/${userId}`,
-        headers: {
-          Authorization: token,
-        },
         data: {
           nickname: getValues('nickname'),
           birth: getValues('birth'),

--- a/src/app/(auth)/signup/_components/DatePick.tsx
+++ b/src/app/(auth)/signup/_components/DatePick.tsx
@@ -29,10 +29,7 @@ const DatePick = ({ register, setDate }: Props) => {
             validate: {
               lessThanToday: (date) => new Date(date) < new Date(),
             },
-            onChange: (e: ChangeEvent<HTMLInputElement>) => {
-              setDate('birth', e.target.value);
-              console.log(e.target.value.length);
-            },
+            onChange: (e: ChangeEvent<HTMLInputElement>) => setDate('birth', e.target.value),
           })}
         />
       </div>

--- a/src/app/(auth)/signup/_components/ProgressBar.tsx
+++ b/src/app/(auth)/signup/_components/ProgressBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const ProgressBar = () => {
   const [barWidth, setBarWidth] = useState(0);
@@ -8,11 +8,11 @@ const ProgressBar = () => {
   }, []);
 
   return (
-    <div className="relative ml-10 h-3 max-w-xl overflow-hidden rounded-full">
-      <div className="absolute h-full w-full bg-gray-200"></div>
+    <div className="relative h-5">
+      <div className="absolute h-5 w-full  rounded-sm bg-gray-200"></div>
       <div
         style={{ width: `${barWidth}%` }}
-        className="relative h-full bg-main-1 transition-all duration-700 ease-out"
+        className="absolute h-5 rounded-sm bg-main-1 transition-all duration-700 ease-out"
       ></div>
     </div>
   );

--- a/src/app/_components/Modal.tsx
+++ b/src/app/_components/Modal.tsx
@@ -1,6 +1,6 @@
+import { RefObject } from 'react';
 import { Card } from '@/components/ui/card';
-
-// import useClickAway from '@/hooks/useClickaway';
+import useClickAway from '@/hooks/useClickaway';
 
 interface ModalProps {
   isOpen: boolean;
@@ -9,31 +9,19 @@ interface ModalProps {
 }
 
 const Modal = ({ isOpen, onClose, children }: ModalProps) => {
-  // Todo: hook 써서 외부 영역 클릭 시 모달 안보이게 [2024/2/27]
-
-  // const modalContentRef = useClickAway((e: MouseEvent | TouchEvent) => {
-  //   onClose();
-  //   const target = e.target as HTMLDivElement;
-  //   console.log(target);
-  //   if (!target.closest('#modal-content')) {
-  //     //모달 외부 클릭 로직
-  //     console.log(target);
-  //     onClose();
-  //   }
-  //   onClose();
-  // });
+  const modalContentRef = useClickAway((e: MouseEvent | TouchEvent) => {
+    const { innerHTML } = e.target as HTMLDivElement;
+    if (innerHTML === '⚡번개 모각코') return;
+    onClose();
+  });
 
   return (
     <>
       {isOpen && (
-        <div
-          // ref={modalContentRef}
-          onClick={onClose}
-          className="fixed inset-0 left-0 right-0 top-0 z-50 flex h-[100svh] max-h-full w-full items-center justify-center overflow-y-auto overflow-x-hidden bg-black/75"
-        >
+        <div className="fixed inset-0 left-0 right-0 top-0 z-50 flex h-[100svh] max-h-full w-full items-center justify-center overflow-y-auto overflow-x-hidden bg-black/75">
           <Card
+            ref={modalContentRef as RefObject<HTMLDivElement>}
             id="modal-content"
-            onClick={(e) => e.stopPropagation()}
             className="z-100 relative w-310pxr rounded-lg opacity-100 shadow"
           >
             {children}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -38,4 +38,6 @@ export const removeItem = (storage: Storage, key: string) => {
   storage.removeItem(key);
 };
 
+export const clearItem = (storage: Storage) => storage.clear();
+
 export const USER_ID_KEY = 'userId';


### PR DESCRIPTION
## 📝 주요 작업 내용
- 로그인과 회원가입을 하기전에 redirection 페이지를 거쳐서 분기시킴
- 로그인한 유저의 로그인/회원가입 페이지 접근 제한
- useClickAway를 이용하여 번객모각코 생성모달 닫게 하기

## 📷 스크린샷 (선택)
깃허브는 회원가입을 하지않았고 카카오톡은 회원가입을 한 상태입니다.


https://github.com/jae-hun-e/LocoMoco/assets/96977881/fb21a4d3-bad8-4627-9338-7f8dad65297f



## 💬 고민 중인 부분 및 참고사항 (선택)
- 지금 경고같은것을 alert를 이용해서 하고 있는데 공통적으로 사용하는 모달이 있으면 좋겠다는 생각을 했어요.

close #68

