### PR TITLE
[#61] 마이페이지 신고목록 UI 구현

### DIFF
--- a/src/app/mypage/report-list/_components/ReportList.tsx
+++ b/src/app/mypage/report-list/_components/ReportList.tsx
@@ -1,0 +1,29 @@
+import { Separator } from '@radix-ui/react-separator';
+import ReportListItem, { Report } from './ReportListItem';
+
+interface ReportListProps {
+  data: Report[];
+  onModifyBtnClick: (id: number) => void;
+  onDeleteBtnClick: (id: number) => void;
+}
+
+const UserList = ({ data, onModifyBtnClick, onDeleteBtnClick }: ReportListProps) => {
+  return (
+    <section>
+      <ul>
+        {data.map((el) => (
+          <div key={el.reportId}>
+            <ReportListItem
+              data={el}
+              onModifyBtnClick={onModifyBtnClick}
+              onDeleteBtnClick={onDeleteBtnClick}
+            />
+            <Separator />
+          </div>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default UserList;

--- a/src/app/mypage/report-list/_components/ReportList.tsx
+++ b/src/app/mypage/report-list/_components/ReportList.tsx
@@ -7,7 +7,7 @@ interface ReportListProps {
   onDeleteBtnClick: (id: number) => void;
 }
 
-const UserList = ({ data, onModifyBtnClick, onDeleteBtnClick }: ReportListProps) => {
+const ReportList = ({ data, onModifyBtnClick, onDeleteBtnClick }: ReportListProps) => {
   return (
     <section>
       <ul>
@@ -26,4 +26,4 @@ const UserList = ({ data, onModifyBtnClick, onDeleteBtnClick }: ReportListProps)
   );
 };
 
-export default UserList;
+export default ReportList;

--- a/src/app/mypage/report-list/_components/ReportListItem.tsx
+++ b/src/app/mypage/report-list/_components/ReportListItem.tsx
@@ -1,0 +1,49 @@
+import { Button } from '@/components/ui/button';
+
+export interface Report {
+  reportId: number;
+  reporterId: number;
+  reportedId: number;
+  content: string;
+}
+
+interface ReportListItemProps {
+  data: Report;
+  onModifyBtnClick: (id: number) => void;
+  onDeleteBtnClick: (id: number) => void;
+}
+
+const ReportListItem = ({ data, onModifyBtnClick, onDeleteBtnClick }: ReportListItemProps) => {
+  return (
+    <li className="w-full flex-col border-b border-solid py-14pxr">
+      <div className="mb-10pxr flex items-center justify-between">
+        신고 대상: {data.reportedId}
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            className="border-1pxr h-30pxr w-50pxr border-solid border-main-1 text-xs text-main-1 hover:border-hover hover:bg-white hover:text-hover"
+            onClick={() => {
+              onModifyBtnClick(data.reportId);
+            }}
+          >
+            수정
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            className="border-1pxr h-30pxr w-50pxr border-solid border-main-1 text-xs text-main-1 hover:border-hover hover:bg-white hover:text-hover"
+            onClick={() => {
+              onDeleteBtnClick(data.reportId);
+            }}
+          >
+            삭제
+          </Button>
+        </div>
+      </div>
+      <p>{data.content}</p>
+    </li>
+  );
+};
+
+export default ReportListItem;

--- a/src/app/mypage/report-list/_components/ReportListItem.tsx
+++ b/src/app/mypage/report-list/_components/ReportListItem.tsx
@@ -4,6 +4,7 @@ export interface Report {
   reportId: number;
   reporterId: number;
   reportedId: number;
+  reportedNickname: string;
   content: string;
 }
 
@@ -17,7 +18,7 @@ const ReportListItem = ({ data, onModifyBtnClick, onDeleteBtnClick }: ReportList
   return (
     <li className="w-full flex-col border-b border-solid py-14pxr">
       <div className="mb-10pxr flex items-center justify-between">
-        신고 대상: {data.reportedId}
+        신고 대상: {data.reportedNickname}
         <div className="flex gap-2">
           <Button
             type="button"

--- a/src/app/mypage/report-list/page.tsx
+++ b/src/app/mypage/report-list/page.tsx
@@ -1,5 +1,54 @@
-const ReportList = () => {
-  return <div>ReportList</div>;
+'use client';
+
+import ReportList from '@/app/mypage/report-list/_components/ReportList';
+
+const data = [
+  {
+    reportId: 1,
+    reporterId: 1,
+    reportedId: 3,
+    content:
+      '안녕하세요, 스토브 입니다. 개인정보 유효기간제 폐지(개정 전 개인정보보호법 제39조의 6)에 따라 휴면으로 분류되었던 회원님의 계정이 활성계정으로 전환될 예정입니다.',
+  },
+  {
+    reportId: 2,
+    reporterId: 1,
+    reportedId: 4,
+    content:
+      '안녕하세요, 스토브 입니다. 개인정보 유효기간제 폐지(개정 전 개인정보보호법 제39조의 6)에 따라 휴면으로 분류되었던 회원님의 계정이 활성계정으로 전환될 예정입니다.',
+  },
+  {
+    reportId: 3,
+    reporterId: 1,
+    reportedId: 5,
+    content:
+      '안녕하세요, 스토브 입니다. 개인정보 유효기간제 폐지(개정 전 개인정보보호법 제39조의 6)에 따라 휴면으로 분류되었던 회원님의 계정이 활성계정으로 전환될 예정입니다.',
+  },
+  {
+    reportId: 4,
+    reporterId: 1,
+    reportedId: 6,
+    content:
+      '안녕하세요, 스토브 입니다. 개인정보 유효기간제 폐지(개정 전 개인정보보호법 제39조의 6)에 따라 휴면으로 분류되었던 회원님의 계정이 활성계정으로 전환될 예정입니다.',
+  },
+];
+
+const ReportPage = () => {
+  const handleModifyButtonClick = (targetId: number) => {
+    console.log(`신고번호 ${targetId}를 수정합니다.`);
+  };
+
+  const handleDeleteButtonClick = (targetId: number) => {
+    console.log(`신고번호 ${targetId}를 삭제합니다.`);
+  };
+
+  return (
+    <ReportList
+      data={data}
+      onModifyBtnClick={handleModifyButtonClick}
+      onDeleteBtnClick={handleDeleteButtonClick}
+    />
+  );
 };
 
-export default ReportList;
+export default ReportPage;

--- a/src/app/mypage/report-list/page.tsx
+++ b/src/app/mypage/report-list/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import ReportList from '@/app/mypage/report-list/_components/ReportList';
+import ReportList from './_components/ReportList';
 
 const data = [
   {
     reportId: 1,
     reporterId: 1,
     reportedId: 3,
+    reportedNickname: '김춘식',
     content:
       '안녕하세요, 스토브 입니다. 개인정보 유효기간제 폐지(개정 전 개인정보보호법 제39조의 6)에 따라 휴면으로 분류되었던 회원님의 계정이 활성계정으로 전환될 예정입니다.',
   },
@@ -14,6 +15,7 @@ const data = [
     reportId: 2,
     reporterId: 1,
     reportedId: 4,
+    reportedNickname: '김춘배',
     content:
       '안녕하세요, 스토브 입니다. 개인정보 유효기간제 폐지(개정 전 개인정보보호법 제39조의 6)에 따라 휴면으로 분류되었던 회원님의 계정이 활성계정으로 전환될 예정입니다.',
   },
@@ -21,6 +23,7 @@ const data = [
     reportId: 3,
     reporterId: 1,
     reportedId: 5,
+    reportedNickname: '김민돌',
     content:
       '안녕하세요, 스토브 입니다. 개인정보 유효기간제 폐지(개정 전 개인정보보호법 제39조의 6)에 따라 휴면으로 분류되었던 회원님의 계정이 활성계정으로 전환될 예정입니다.',
   },
@@ -28,6 +31,7 @@ const data = [
     reportId: 4,
     reporterId: 1,
     reportedId: 6,
+    reportedNickname: '김시리',
     content:
       '안녕하세요, 스토브 입니다. 개인정보 유효기간제 폐지(개정 전 개인정보보호법 제39조의 6)에 따라 휴면으로 분류되었던 회원님의 계정이 활성계정으로 전환될 예정입니다.',
   },


### PR DESCRIPTION
# [#61] 마이페이지 신고목록 UI 구현

## 📝 주요 작업 내용
- 신고 목록 UI 구현

## 📷 스크린샷 (선택)
<img width="334" alt="스크린샷 2024-03-10 오후 8 07 25" src="https://github.com/jae-hun-e/LocoMoco/assets/62047243/3cfad954-019a-488e-ac90-976959e288cc">


## 💬 고민 중인 부분 및 참고사항 (선택)
- 디자인에 추가할 게 있는지 궁금합니다
- 백엔드와 논의 후 신고 대상 닉네임이나 프로필이미지도 보이도록 개선 예정입니다.

close #61 

