### PR TITLE
[#70] 홈페이지 동명검색 및 필터 사용자 입력 적용

### DIFF
--- a/src/apis/core.ts
+++ b/src/apis/core.ts
@@ -5,23 +5,12 @@ const axiosInstance: AxiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
   timeout: 10000,
   headers: { 'Content-Type': 'application/json' },
+  paramsSerializer: (params) => qs.stringify(params, { arrayFormat: 'repeat' }),
 });
 
 // todo: token 관련 처리는 추후 추가해야함 [24/02/07]
 axiosInstance.interceptors.request.use(
   (config) => {
-    if (config.params) {
-      const paramsValues = Object.values(config.params);
-      for (const value of paramsValues) {
-        if (Array.isArray(value)) {
-          config.paramsSerializer = {
-            encode: (params) => qs.stringify(params, { arrayFormat: 'repeat' }),
-          };
-          break;
-        }
-      }
-    }
-
     if (typeof window !== 'undefined') {
       const token = localStorage.getItem('token');
       if (token) config.headers['Authorization'] = `Bearer ${token}`;

--- a/src/apis/mgcList/useMGCTotalList.ts
+++ b/src/apis/mgcList/useMGCTotalList.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import client from '../core';
 
 export interface TotalSearchProps {
-  search: string;
+  search?: string;
   searchType: 'TOTAL' | 'LOCATION';
   tags?: number[];
 }

--- a/src/app/(home)/_components/MapSection.tsx
+++ b/src/app/(home)/_components/MapSection.tsx
@@ -32,8 +32,17 @@ const MapSection = ({ data }: MGCListType) => {
     setOpen(true);
   };
 
-  const { clusterer, map, mapRef, createMarker, changeCenter, removeMarker, movePosition, isLoad } =
-    useCreateKakaoMap({ isCustomlevelControl: false, handleMouseUp: handleMouseUp });
+  const {
+    clusterer,
+    map,
+    mapRef,
+    createMarker,
+    changeCenter,
+    removeMarker,
+    movePosition,
+    isLoad,
+    getAddressByCoorinates,
+  } = useCreateKakaoMap({ isCustomlevelControl: false, handleMouseUp: handleMouseUp });
   const renderMarker = useRenderMarkerByData(openBottomSheetAndUpdate, handleMouseUp);
 
   useEffect(() => {
@@ -47,6 +56,7 @@ const MapSection = ({ data }: MGCListType) => {
 
     if (latitude !== 0 && longitude !== 0) {
       changeCenter(latitude, longitude);
+      getAddressByCoorinates(latitude, longitude);
     }
   }, [centerPosition, changeCenter]);
 

--- a/src/app/(home)/_components/MapSection.tsx
+++ b/src/app/(home)/_components/MapSection.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import CreateBtn from '@/app/_components/CreateBtn';
 import MGCList from '@/app/_components/MGCList/MGCList';
+import { toast } from '@/components/ui/use-toast';
 import useCreateKakaoMap from '@/hooks/useCreateKakaoMap';
 import useRenderMarkerByData from '@/hooks/useRenderMarkerByData';
 import useCenterPosition from '@/store/useCenterPosition';
+import useSearchInputValueStore from '@/store/useSearchValueStore';
 import { MGCList as MGCListType, MGCSummary } from '@/types/MGCList';
 import BottomSheet from './BottomSheet';
 import Map from './Map';
@@ -51,14 +53,32 @@ const MapSection = ({ data }: MGCListType) => {
     }
   }, [clusterer, data, renderMarker]);
 
+  const { searchValue, setSearchValue } = useSearchInputValueStore();
+
+  const changeAddress = useCallback(
+    async (latitude: number, longitude: number) => {
+      const address = await getAddressByCoorinates(latitude, longitude);
+
+      if (!address) {
+        toast({
+          description: '오류가 발생했습니다.',
+        });
+        return;
+      }
+
+      setSearchValue({ ...searchValue, address });
+    },
+    [getAddressByCoorinates],
+  );
+
   useEffect(() => {
     const { latitude, longitude } = centerPosition;
 
     if (latitude !== 0 && longitude !== 0) {
       changeCenter(latitude, longitude);
-      getAddressByCoorinates(latitude, longitude);
+      changeAddress(latitude, longitude);
     }
-  }, [centerPosition, changeCenter]);
+  }, [centerPosition, changeCenter, changeAddress]);
 
   return (
     <>

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,11 +1,17 @@
 'use client';
 
-import useMGCList from '@/apis/mgcList/useMGCList';
+import useMGCTotalList from '@/apis/mgcList/useMGCTotalList';
+import useSearchInputValueStore from '@/store/useSearchValueStore';
 import MapSection from './_components/MapSection';
 import SearchBarFilter from './_components/SearchBarFilter';
 
 const Home = () => {
-  const { data } = useMGCList([1, 2]);
+  const { searchValue } = useSearchInputValueStore();
+  const { data } = useMGCTotalList({
+    search: searchValue.address,
+    searchType: 'LOCATION',
+    tags: searchValue.tags,
+  });
 
   return (
     <div className="relative -left-20pxr w-[100vw]">

--- a/src/app/_components/filter/Filter.tsx
+++ b/src/app/_components/filter/Filter.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import { AccordionContent, AccordionTrigger } from '@/components/ui/accordion';
+import useSearchInputValueStore from '@/store/useSearchValueStore';
 import { SearchFilterForm } from '@/types/searchFilterForm';
 import { Accordion, AccordionItem } from '@radix-ui/react-accordion';
 import FilterContent from './FilterContent';
 
 const Filter = () => {
+  const { searchValue, setSearchValue } = useSearchInputValueStore();
+
   const handleSubmit = (data: SearchFilterForm) => {
     const values = Object.values(data);
     const tags = [].concat(...values);
-    // TODO: 백엔드 api 완성되면 api 연결하기 [24.02.22]
-    console.log('필터링할 태그 배열', tags);
+    setSearchValue({ ...searchValue, tags: tags.filter((tagId) => tagId !== 0) });
   };
 
   return (

--- a/src/app/_components/filter/FilterContent.tsx
+++ b/src/app/_components/filter/FilterContent.tsx
@@ -6,54 +6,59 @@ import { AccordionTrigger } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
 import { SearchFilterForm } from '@/types/searchFilterForm';
+import { getCategoryOptions } from '@/utils/getQueryOptions';
+import { useQueryClient } from '@tanstack/react-query';
 import TypeCheckList from './TypeCheckList';
 
-const MGCType = {
-  all: 1,
-  ThunderMGC: 2,
-  LocationConfirmed: 3,
-  LocationNotConfirmed: 4,
-} as const;
+interface Category {
+  category_id: number;
+  category_name: string;
+  input_type: 'COMBOBOX' | 'CHECKBOX' | 'RADIOGROUP';
+  tags: {
+    tag_id: number;
+    tag_name: string;
+  }[];
+}
 
-const languageType = {
-  all: 1,
-  JAVASCRIPT: 5,
-  JAVA: 6,
-  PYTHON: 7,
-} as const;
-
-const studyType = {
-  all: 1,
-  web: 8,
-  FE: 9,
-  BE: 10,
-} as const;
-
-// const MGCType = {
-//   all: {id: 1, text: '전체'},
-//   ThunderMGC: {id: 1, text: '번개'},
-//   LocationConfirmed: {id: 1, text: '장소확정'},
-//   LocationNotConfirmed: {id: 1, text: '장소미정'},
-// } as const;
-
-// const languageType = {
-//   all: '전체',
-//   JAVASCRIPT: 'JAVASCRIPT',
-//   JAVA: 'JAVA',
-//   PYTHON: 'PYTHON',
-// } as const;
-
-// const studyType = {
-//   all: '전체',
-//   web: 'web',
-//   FE: 'FE',
-//   BE: 'BE',
-// } as const;
+export interface FilterCategoryList {
+  tagId: number;
+  tagName: string;
+  categoryName: string;
+}
 
 const FilterContent = ({ onSubmit }: { onSubmit: (data: SearchFilterForm) => void }) => {
-  const MGCTypes = Object.values(MGCType);
-  const languageTypes = Object.values(languageType);
-  const studyTypes = Object.values(studyType);
+  const queryClient = useQueryClient();
+  const categoryList = queryClient.getQueryData(getCategoryOptions().queryKey);
+
+  const setFilterList = (filterCategoryData?: Category[]) => {
+    const filterCategoryList: FilterCategoryList[] = [];
+
+    filterCategoryData?.forEach(({ category_name, tags }) => {
+      tags.forEach(({ tag_id, tag_name }) => {
+        filterCategoryList.push({ tagId: tag_id, tagName: tag_name, categoryName: category_name });
+      });
+    });
+
+    return filterCategoryList;
+  };
+
+  const allCategory = [
+    {
+      categoryName: '',
+      tagId: 0,
+      tagName: '전체',
+    },
+  ];
+
+  const MGCTypes = setFilterList(
+    categoryList?.filter(({ category_name }) => category_name === '모각코 유형'),
+  );
+  const languageTypes = setFilterList(
+    categoryList?.filter(({ category_name }) => category_name === '개발 언어'),
+  );
+  const studyTypes = setFilterList(
+    categoryList?.filter(({ category_name }) => category_name === '개발 유형'),
+  );
 
   const form = useForm<SearchFilterForm>({
     defaultValues: {
@@ -76,17 +81,17 @@ const FilterContent = ({ onSubmit }: { onSubmit: (data: SearchFilterForm) => voi
         >
           <div className="flex h-120pxr flex-row justify-between pt-10pxr">
             <TypeCheckList
-              types={MGCTypes}
+              types={allCategory.concat(MGCTypes)}
               control={form.control}
               type="mgc"
             />
             <TypeCheckList
-              types={languageTypes}
+              types={allCategory.concat(languageTypes)}
               control={form.control}
               type="language"
             />
             <TypeCheckList
-              types={studyTypes}
+              types={allCategory.concat(studyTypes)}
               control={form.control}
               type="study"
             />

--- a/src/app/_components/filter/FilterContent.tsx
+++ b/src/app/_components/filter/FilterContent.tsx
@@ -10,16 +10,6 @@ import { getCategoryOptions } from '@/utils/getQueryOptions';
 import { useQueryClient } from '@tanstack/react-query';
 import TypeCheckList from './TypeCheckList';
 
-interface Category {
-  category_id: number;
-  category_name: string;
-  input_type: 'COMBOBOX' | 'CHECKBOX' | 'RADIOGROUP';
-  tags: {
-    tag_id: number;
-    tag_name: string;
-  }[];
-}
-
 export interface FilterCategoryList {
   tagId: number;
   tagName: string;
@@ -30,10 +20,13 @@ const FilterContent = ({ onSubmit }: { onSubmit: (data: SearchFilterForm) => voi
   const queryClient = useQueryClient();
   const categoryList = queryClient.getQueryData(getCategoryOptions().queryKey);
 
-  const setFilterList = (filterCategoryData?: Category[]) => {
+  const getFilterList = (categoryName: string) => {
+    const categoryData = categoryList?.filter(
+      ({ category_name }) => category_name === categoryName,
+    );
     const filterCategoryList: FilterCategoryList[] = [];
 
-    filterCategoryData?.forEach(({ category_name, tags }) => {
+    categoryData?.forEach(({ category_name, tags }) => {
       tags.forEach(({ tag_id, tag_name }) => {
         filterCategoryList.push({ tagId: tag_id, tagName: tag_name, categoryName: category_name });
       });
@@ -50,15 +43,9 @@ const FilterContent = ({ onSubmit }: { onSubmit: (data: SearchFilterForm) => voi
     },
   ];
 
-  const MGCTypes = setFilterList(
-    categoryList?.filter(({ category_name }) => category_name === '모각코 유형'),
-  );
-  const languageTypes = setFilterList(
-    categoryList?.filter(({ category_name }) => category_name === '개발 언어'),
-  );
-  const studyTypes = setFilterList(
-    categoryList?.filter(({ category_name }) => category_name === '개발 유형'),
-  );
+  const MGCTypes = getFilterList('모각코 유형');
+  const languageTypes = getFilterList('개발 언어');
+  const studyTypes = getFilterList('개발 유형');
 
   const form = useForm<SearchFilterForm>({
     defaultValues: {

--- a/src/app/_components/filter/TypeCheckList.tsx
+++ b/src/app/_components/filter/TypeCheckList.tsx
@@ -3,26 +3,13 @@ import { Control, ControllerRenderProps } from 'react-hook-form';
 import { Checkbox } from '@/components/ui/checkbox';
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { SearchFilterForm } from '@/types/searchFilterForm';
+import { FilterCategoryList } from './FilterContent';
 
 interface TypeCheckListProps {
-  types: number[];
+  types: FilterCategoryList[];
   control: Control<SearchFilterForm>;
   type: keyof SearchFilterForm;
 }
-
-// TODO: filted item 백엔드와 결정 후 변경 [24.02.22]
-const filtedTextById = [
-  { id: 1, text: '전체' },
-  { id: 2, text: '번개' },
-  { id: 3, text: '장소확정' },
-  { id: 4, text: '장소미정' },
-  { id: 5, text: 'JAVASCRIPT' },
-  { id: 6, text: 'JAVA' },
-  { id: 7, text: 'PYTHON' },
-  { id: 8, text: 'web' },
-  { id: 9, text: 'FE' },
-  { id: 10, text: 'BE' },
-];
 
 const TypeCheckList = ({ types, control, type }: TypeCheckListProps) => {
   const handleCheckedChange = (
@@ -30,13 +17,13 @@ const TypeCheckList = ({ types, control, type }: TypeCheckListProps) => {
     item: number,
     field: ControllerRenderProps<SearchFilterForm, keyof SearchFilterForm>,
   ) => {
-    if (item === 1) {
-      return checked ? field.onChange([...types]) : field.onChange([]);
+    if (item === 0) {
+      return checked ? field.onChange([...types.map((type) => type.tagId)]) : field.onChange([]);
     } else {
-      if (field.value.includes(1)) {
+      if (field.value.includes(0)) {
         return checked
           ? field.onChange([...field.value])
-          : field.onChange(field.value?.filter((value) => value !== item && value !== 1));
+          : field.onChange(field.value?.filter((value) => value !== item && value !== 0));
       } else {
         return checked
           ? field.onChange([...field.value, item])
@@ -54,23 +41,26 @@ const TypeCheckList = ({ types, control, type }: TypeCheckListProps) => {
           <FormItem>
             {types.map((item) => (
               <FormField
-                key={item}
+                key={item.tagId}
                 control={control}
                 name={type}
                 render={({ field }) => {
                   return (
                     <FormItem
-                      key={item}
+                      key={item.tagId}
                       className="flex flex-row items-start space-x-3 space-y-0"
                     >
                       <FormControl>
                         <Checkbox
-                          checked={field.value?.includes(item)}
-                          onCheckedChange={(checked) => handleCheckedChange(checked, item, field)}
+                          checked={field.value?.includes(item.tagId)}
+                          onCheckedChange={(checked) =>
+                            handleCheckedChange(checked, item.tagId, field)
+                          }
                         />
                       </FormControl>
                       <FormLabel className="text-sm font-normal">
-                        {filtedTextById.find((e) => e.id === item)?.text}
+                        {/* {filtedTextById.find((e) => e.id === item)?.text} */}
+                        {item.tagName}
                       </FormLabel>
                     </FormItem>
                   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,7 +38,7 @@ const RootLayout = async ({
       >
         <Script
           type="text/javascript"
-          src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_KEY}&autoload=false&libraries=clusterer`}
+          src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_KEY}&autoload=false&libraries=clusterer,services`}
           strategy="beforeInteractive"
         />
         <Provider>

--- a/src/store/useSearchValueStore.ts
+++ b/src/store/useSearchValueStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+interface SearchValueStore {
+  searchValue: Position;
+  setSearchValue: (newSearchValue: Position) => void;
+}
+
+interface Position {
+  address?: string;
+  tags?: number[];
+}
+
+export const useSearchValueStore = create<SearchValueStore>()(
+  devtools(
+    (set) => ({
+      searchValue: {
+        address: undefined,
+        tags: undefined,
+      },
+      setSearchValue: (newSearchValue: Position) => set({ searchValue: newSearchValue }),
+    }),
+    {
+      name: 'current-search-value',
+    },
+  ),
+);
+
+export default useSearchValueStore;


### PR DESCRIPTION
## 📝 주요 작업 내용
- 필터 카테고리 api 연동 후 서버 값으로 변경
- 수정된 api에 맞춰서 검색 기능 구현
    - 태그 + 동명을 관리하는 전역 상태 생성하여 관리
    -  고정된 params값에서 사용자가 입력 or 선택한 값으로 api 호출
    
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷 스크린샷 (선택)
![검색+필터적용](https://github.com/jae-hun-e/LocoMoco/assets/66080362/1d953b9f-c8b5-46f5-bb97-1a473a245493)

## 💬 고민 중인 부분 및 참고사항 (선택)

### 참고사항
- `useCreateKakaoMap.ts`에 동명을 받아오는 함수을 추가했습니다. 모각코 생성시에 이 함수를 활용해서 동명을 받아오면 됩니다!
```
  const getAddressByCoorinates = useCallback(
    async (latitude: number, longitude: number) => {
      try {
        const addressName = await coord2RegionCodePromise(longitude, latitude);

        return addressName;
      } catch (error) {
        console.error(error);
        return;
      }
    },
    [coord2RegionCodePromise],
  );
```

close #70 

