### PR TITLE
[#89 ] 마이페이지 내 모각코페이지들 API연결

### DIFF
--- a/src/app/mypage/(sub-page)/_components/button/LikeMGCAreaButtons.tsx
+++ b/src/app/mypage/(sub-page)/_components/button/LikeMGCAreaButtons.tsx
@@ -20,9 +20,9 @@ const LikeMGCAreaButtons = ({ MGCId }: { MGCId: number }) => {
         onClick={handleParticipation}
       />
       <MainStyleButton
-        content="찜하기 취소"
+        content="취소"
         layout="flex-grow-0"
-        className="bg-layer-5 px-5pxr"
+        className="bg-layer-5 px-10pxr"
         onClick={handleCancelLike}
       />
     </div>

--- a/src/app/mypage/(sub-page)/current-join-mgc/_hooks/useGetCurrentJoinMGC.ts
+++ b/src/app/mypage/(sub-page)/current-join-mgc/_hooks/useGetCurrentJoinMGC.ts
@@ -1,0 +1,20 @@
+import client from '@/apis/core';
+import { MGCSummary } from '@/types/MGCList';
+import { useQuery } from '@tanstack/react-query';
+
+const getGetCurrentJoinMGC = async ({ userId }: { userId: number }) => {
+  try {
+    return await client.get<MGCSummary[]>({ url: `/users/${userId}/mogakko/ongoing` });
+  } catch (error) {
+    console.error('현재 진행 중 모각코 정보를 불러오는데 실패했습니다.', error);
+  }
+};
+
+export const useGetCurrentJoinMGC = ({ userId }: { userId: number }) => {
+  const { data, ...rest } = useQuery({
+    queryKey: ['currentMGC', userId],
+    queryFn: () => getGetCurrentJoinMGC({ userId }),
+  });
+
+  return { currentMGCs: data, ...rest };
+};

--- a/src/app/mypage/(sub-page)/current-join-mgc/page.tsx
+++ b/src/app/mypage/(sub-page)/current-join-mgc/page.tsx
@@ -2,6 +2,8 @@
 
 import MGCSummaryInfo from '@/app/mypage/(sub-page)/_components/MGCSummaryInfo';
 import { useGetCurrentJoinMGC } from '@/app/mypage/(sub-page)/current-join-mgc/_hooks/useGetCurrentJoinMGC';
+// TODO: API 연동 후 실데이터로 변경 [24/03/14]
+import { dummyData } from '@/constants/mgcListDummy';
 import { getItem } from '@/utils/storage';
 
 const CurrentMGC = () => {
@@ -12,17 +14,17 @@ const CurrentMGC = () => {
 
   const { currentMGCs } = useGetCurrentJoinMGC({ userId: Number(userId) });
 
+  console.log('currentMGCs', currentMGCs);
   return (
     <>
-      {currentMGCs &&
-        currentMGCs.map((mgc) => (
-          <MGCSummaryInfo
-            MGCInfo={mgc}
-            key={mgc.id}
-          >
-            <MGCSummaryInfo.Chatting MGCId={mgc.id} />
-          </MGCSummaryInfo>
-        ))}
+      {dummyData.map((mgc) => (
+        <MGCSummaryInfo
+          MGCInfo={mgc}
+          key={mgc.id}
+        >
+          <MGCSummaryInfo.Chatting MGCId={mgc.id} />
+        </MGCSummaryInfo>
+      ))}
     </>
   );
 };

--- a/src/app/mypage/(sub-page)/current-join-mgc/page.tsx
+++ b/src/app/mypage/(sub-page)/current-join-mgc/page.tsx
@@ -1,20 +1,28 @@
+'use client';
+
 import MGCSummaryInfo from '@/app/mypage/(sub-page)/_components/MGCSummaryInfo';
-import { dummyData } from '@/constants/mgcListDummy';
+import { useGetCurrentJoinMGC } from '@/app/mypage/(sub-page)/current-join-mgc/_hooks/useGetCurrentJoinMGC';
+import { getItem } from '@/utils/storage';
 
 const CurrentMGC = () => {
-  // TODO: API 연동 후 실데이터로 변경 [24/03/05]
-  const currentMGCData = dummyData;
+  let userId;
+  if (typeof window !== 'undefined') {
+    userId = getItem<string | undefined>(localStorage, 'userId');
+  }
+
+  const { currentMGCs } = useGetCurrentJoinMGC({ userId: Number(userId) });
 
   return (
     <>
-      {currentMGCData.map((mgc) => (
-        <MGCSummaryInfo
-          MGCInfo={mgc}
-          key={mgc.id}
-        >
-          <MGCSummaryInfo.Chatting MGCId={mgc.id} />
-        </MGCSummaryInfo>
-      ))}
+      {currentMGCs &&
+        currentMGCs.map((mgc) => (
+          <MGCSummaryInfo
+            MGCInfo={mgc}
+            key={mgc.id}
+          >
+            <MGCSummaryInfo.Chatting MGCId={mgc.id} />
+          </MGCSummaryInfo>
+        ))}
     </>
   );
 };

--- a/src/app/mypage/(sub-page)/end-join-mgc/_hooks/useGetEndMGC.ts
+++ b/src/app/mypage/(sub-page)/end-join-mgc/_hooks/useGetEndMGC.ts
@@ -1,0 +1,20 @@
+import client from '@/apis/core';
+import { MGCSummary } from '@/types/MGCList';
+import { useQuery } from '@tanstack/react-query';
+
+const getGetEndMGC = async ({ userId }: { userId: number }) => {
+  try {
+    return await client.get<MGCSummary[]>({ url: `/users/${userId}/mogakko/complete` });
+  } catch (error) {
+    console.error('종료된 모각코 정보를 불러오는데 실패했습니다.', error);
+  }
+};
+
+export const useGetEndMGC = ({ userId }: { userId: number }) => {
+  const { data, ...rest } = useQuery({
+    queryKey: ['endMGC', userId],
+    queryFn: () => getGetEndMGC({ userId }),
+  });
+
+  return { endMGCs: data, ...rest };
+};

--- a/src/app/mypage/(sub-page)/end-join-mgc/page.tsx
+++ b/src/app/mypage/(sub-page)/end-join-mgc/page.tsx
@@ -1,13 +1,24 @@
+'use client';
+
 import MGCSummaryInfo from '@/app/mypage/(sub-page)/_components/MGCSummaryInfo';
+import { useGetEndMGC } from '@/app/mypage/(sub-page)/end-join-mgc/_hooks/useGetEndMGC';
+// TODO: API 연동 후 실데이터로 변경 [24/03/14]
 import { dummyData } from '@/constants/mgcListDummy';
+import { getItem } from '@/utils/storage';
 
 const EndMGC = () => {
-  // TODO: API 연동 후 실데이터로 변경 [24/03/05]
-  const endMGCData = dummyData;
+  let userId;
+  if (typeof window !== 'undefined') {
+    userId = getItem<string | undefined>(localStorage, 'userId');
+  }
+
+  const { endMGCs } = useGetEndMGC({ userId: Number(userId) });
+
+  console.log('endMGCs', endMGCs);
 
   return (
     <>
-      {endMGCData.map((mgc) => (
+      {dummyData.map((mgc) => (
         <MGCSummaryInfo
           MGCInfo={mgc}
           key={mgc.id}

--- a/src/app/mypage/(sub-page)/like-mgc/_hooks/useGetLikeMGC.ts
+++ b/src/app/mypage/(sub-page)/like-mgc/_hooks/useGetLikeMGC.ts
@@ -6,7 +6,7 @@ const getGetLikeMGC = async ({ userId }: { userId: number }) => {
   try {
     return await client.get<MGCSummary[]>({ url: `/users/${userId}/mogakko/like` });
   } catch (error) {
-    console.error('마이페이지 정보를 불러오는데 실패했습니다.', error);
+    console.error('찜한 모각코 정보를 불러오는데 실패했습니다.', error);
   }
 };
 

--- a/src/app/mypage/(sub-page)/like-mgc/_hooks/useGetLikeMGC.ts
+++ b/src/app/mypage/(sub-page)/like-mgc/_hooks/useGetLikeMGC.ts
@@ -1,0 +1,20 @@
+import client from '@/apis/core';
+import { MGCSummary } from '@/types/MGCList';
+import { useQuery } from '@tanstack/react-query';
+
+const getGetLikeMGC = async ({ userId }: { userId: number }) => {
+  try {
+    return await client.get<MGCSummary[]>({ url: `/users/${userId}/mogakko/like` });
+  } catch (error) {
+    console.error('마이페이지 정보를 불러오는데 실패했습니다.', error);
+  }
+};
+
+export const useGetLikeMGC = ({ userId }: { userId: number }) => {
+  const { data, ...rest } = useQuery({
+    queryKey: ['likeMGC', userId],
+    queryFn: () => getGetLikeMGC({ userId }),
+  });
+
+  return { likeMGCs: data, ...rest };
+};

--- a/src/app/mypage/(sub-page)/like-mgc/page.tsx
+++ b/src/app/mypage/(sub-page)/like-mgc/page.tsx
@@ -1,20 +1,28 @@
+'use client';
+
 import MGCSummaryInfo from '@/app/mypage/(sub-page)/_components/MGCSummaryInfo';
-import { dummyData } from '@/constants/mgcListDummy';
+import { useGetLikeMGC } from '@/app/mypage/(sub-page)/like-mgc/_hooks/useGetLikeMGC';
+import { getItem } from '@/utils/storage';
 
 const LikeMGC = () => {
-  // TODO: API 연동 후 실데이터로 변경 [24/03/05]
-  const likeMGCData = dummyData;
+  let userId;
+  if (typeof window !== 'undefined') {
+    userId = getItem<string | undefined>(localStorage, 'userId');
+  }
+
+  const { likeMGCs } = useGetLikeMGC({ userId: Number(userId) });
 
   return (
     <>
-      {likeMGCData.map((mgc) => (
-        <MGCSummaryInfo
-          MGCInfo={mgc}
-          key={mgc.id}
-        >
-          <MGCSummaryInfo.LikeMGCArea MGCId={mgc.id} />
-        </MGCSummaryInfo>
-      ))}
+      {likeMGCs &&
+        likeMGCs.map((mgc) => (
+          <MGCSummaryInfo
+            MGCInfo={mgc}
+            key={mgc.id}
+          >
+            <MGCSummaryInfo.LikeMGCArea MGCId={mgc.id} />
+          </MGCSummaryInfo>
+        ))}
     </>
   );
 };

--- a/src/app/mypage/_components/UserInfo.tsx
+++ b/src/app/mypage/_components/UserInfo.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useMypageInfo } from '@/app/mypage/_hooks/useMypageInfo';
+import MainStyleButton from '@/components/MainStyleButton';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { routes } from '@/constants/routeURL';
+import { getItem } from '@/utils/storage';
+import Image from 'next/image';
+import Link from 'next/link';
+
+const UserInfo = () => {
+  let userId;
+  if (typeof window !== 'undefined') {
+    userId = getItem<string | undefined>(localStorage, 'userId');
+  }
+
+  const { myInfo } = useMypageInfo({ userId: Number(userId) });
+
+  if (!myInfo) return <div>로딩중...</div>;
+
+  return (
+    <section className="my-5">
+      <div className="flex gap-4">
+        <Avatar className="h-100pxr w-100pxr rounded-full">
+          <AvatarImage
+            src={myInfo.profileImage ? myInfo.profileImage.path : '/oh.png'}
+            alt="유저 이미지"
+          />
+          <AvatarFallback>
+            <Image
+              src={'/oh.png'}
+              alt={'cn'}
+              width={100}
+              height={100}
+            />
+          </AvatarFallback>
+        </Avatar>
+        <div className="flex flex-grow flex-col justify-center gap-2">
+          <div className="mx-auto flex flex-col justify-center">
+            <p>닉네임 : {myInfo.nickname}</p>
+            <div className="flex gap-6">
+              <p>성별 : {myInfo.gender ? '남성' : '여성'}</p>
+              <p>나이 : {new Date().getFullYear() - Number(myInfo.birth.split('-')[0])}세</p>
+            </div>
+            <p>온도 : {myInfo.temperature}</p>
+          </div>
+        </div>
+      </div>
+
+      <Link href={routes.changeMyInfo}>
+        <MainStyleButton
+          content="개인정보 수정하기"
+          layout="h-33pxr"
+        />
+      </Link>
+    </section>
+  );
+};
+
+export default UserInfo;

--- a/src/app/mypage/_hooks/useMypageInfo.ts
+++ b/src/app/mypage/_hooks/useMypageInfo.ts
@@ -1,0 +1,34 @@
+import client from '@/apis/core';
+import { useQuery } from '@tanstack/react-query';
+
+interface MypageInfoProps {
+  userId: number;
+  nickname: string;
+  birth: string;
+  gender: string;
+  temperature: number;
+  job: string;
+  email: string;
+  profileImage: {
+    imageId: number;
+    path: string;
+  };
+  provider: string;
+}
+
+const getMypageInfo = async ({ userId }: { userId: number }) => {
+  try {
+    return await client.get<MypageInfoProps>({ url: `/users/${userId}` });
+  } catch (error) {
+    console.error('마이페이지 정보를 불러오는데 실패했습니다.', error);
+  }
+};
+
+export const useMypageInfo = ({ userId }: { userId: number }) => {
+  const { data, ...rest } = useQuery({
+    queryKey: ['mypage', userId],
+    queryFn: () => getMypageInfo({ userId }),
+  });
+
+  return { myInfo: data, ...rest };
+};

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,12 +1,15 @@
-import MainStyleButton from '@/components/MainStyleButton';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+'use client';
+
+import UserInfo from '@/app/mypage/_components/UserInfo';
 import { Separator } from '@/components/ui/separator';
 import { userInfoDummy } from '@/constants/mypageDummyData';
 import { routes } from '@/constants/routeURL';
 import { ChevronRightIcon } from 'lucide-react';
-import Image from 'next/image';
 import Link from 'next/link';
 
+/* TODO: BE에게 요청사항 [24/03/13]
+1. 마이페이지 정보에 찜한, 진행중, 종료 모각코 개수 담은 필드 넘겨주세요!
+ */
 const MyPage = () => {
   const myActivities = [
     { title: '내가 찜한 모각코', link: routes.likeMGC, count: userInfoDummy.likeMGC?.length || 0 },
@@ -37,43 +40,7 @@ const MyPage = () => {
   return (
     <section>
       {/*유저정보*/}
-      <section className="my-5">
-        <div className="flex gap-4">
-          <Avatar className="h-100pxr w-100pxr rounded-full">
-            <AvatarImage
-              src="https://github.com/shadcn.png"
-              alt="유저 이미지"
-            />
-            <AvatarFallback>
-              <Image
-                src={'/oh.png'}
-                alt={'cn'}
-                width={100}
-                height={100}
-              />
-            </AvatarFallback>
-          </Avatar>
-          <div className="flex flex-grow flex-col justify-center gap-2">
-            <div className="mx-auto flex flex-col justify-center">
-              <p>닉네임 : {userInfoDummy.nickname}</p>
-              <div className="flex gap-6">
-                <p>성별 : {userInfoDummy.gender ? '남성' : '여성'}</p>
-                <p>
-                  나이 : {new Date().getFullYear() - Number(userInfoDummy.birth.split('-')[0])}세
-                </p>
-              </div>
-              <p>온도 : {userInfoDummy.temperature}</p>
-            </div>
-          </div>
-        </div>
-
-        <Link href={routes.changeMyInfo}>
-          <MainStyleButton
-            content="개인정보 수정하기"
-            layout="h-33pxr"
-          />
-        </Link>
-      </section>
+      <UserInfo />
 
       {/*나의 활동*/}
       <section className="mb-10 flex flex-col gap-4 font-bold">

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -8,7 +8,8 @@ import { ChevronRightIcon } from 'lucide-react';
 import Link from 'next/link';
 
 /* TODO: BE에게 요청사항 [24/03/13]
-1. 마이페이지 정보에 찜한, 진행중, 종료 모각코 개수 담은 필드 넘겨주세요!
+  1. 마이페이지 정보에 찜한, 진행중, 종료 모각코 개수 담은 필드 넘겨주세요!
+  2. 진행중, 종료 모각코도 찜한 모각코 처럼 MGCSummary 타입으로 넘겨주세요...
  */
 const MyPage = () => {
   const myActivities = [


### PR DESCRIPTION
## 📝 주요 작업 내용

- 각각의 마이페이지에 모각코 API만 연결을 한 상태입니다.
- 이 중 BE와 협의가 필요한부분이 생겨 작업이 중지되었습니다.




## 💬 고민 중인 부분 및 참고사항

### 고민 중 
mypage detail에 각각 모각코 정보의 개수를 담아서 주는 거라면 숫자를 띄워줄 수 있지만 
모든 정보를 넘겨받아 length로 몇개인지를 띄우는 거라면 mypage에서 보여주는 정보에 비해 가지고 있는 정보가 많습니다.(로딩이 오래걸려집니다.)
1. 찜한, 참여중인, 종료된 모각코 개수의 정보가 중요한게 아니라면 마이페이지에서 보여주지 않는 방법 
2. 중요한 정보라면 mypage detail API 내에 개수만 담아서 받아오는 방법
이 둘중 고민 중입니다. 


### 참고사항
- BE와 논의 사항
  - 현재 찜하기는 MGCSummary 타입 형태로 데이터가 넘어오지만 진행 중, 종료된 모각코는 MGCDetail 타입 형태로 데이터가 넘어옵니다.
  - 미리보기에는 필요없는 데이터들이므로 MGCSummary로 변경을 요청드릴 예정입니다.

close #89

