### PR TITLE
[#79] 마이페이지 신고 목록 API 연결

### DIFF
--- a/src/apis/report/useDeleteReportList.ts
+++ b/src/apis/report/useDeleteReportList.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import client from '../core';
+
+export const deleteReportList = async (targetId: number) => {
+  return await client.delete({
+    url: `/reports/${targetId}`,
+  });
+};
+
+const useDeleteReportlist = (targetId: number) => {
+  const queryClient = useQueryClient();
+
+  const { mutate, ...rest } = useMutation({
+    mutationFn: () => deleteReportList(targetId),
+    onSuccess() {
+      queryClient.invalidateQueries({ queryKey: ['reports'] });
+    },
+  });
+
+  return { deleteReportList: mutate, ...rest };
+};
+
+export default useDeleteReportlist;

--- a/src/apis/report/useDeleteReportList.ts
+++ b/src/apis/report/useDeleteReportList.ts
@@ -1,13 +1,14 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import client from '../core';
 
-export const deleteReportList = async (targetId: number) => {
+export const deleteReportList = async (targetId: number | undefined) => {
+  if (typeof targetId === 'undefined') return;
   return await client.delete({
     url: `/reports/${targetId}`,
   });
 };
 
-const useDeleteReportlist = (targetId: number) => {
+const useDeleteReportlist = (targetId: number | undefined) => {
   const queryClient = useQueryClient();
 
   const { mutate, ...rest } = useMutation({

--- a/src/apis/report/useGetReportList.ts
+++ b/src/apis/report/useGetReportList.ts
@@ -1,0 +1,19 @@
+import { Report } from '@/types/report';
+import { useQuery } from '@tanstack/react-query';
+import client from '../core';
+
+export const getReportList = async () => {
+  return await client.get<Report[]>({
+    url: `/reports`,
+    params: { cursor: 1, pageSize: 10 },
+  });
+};
+
+const useGetReportList = () => {
+  return useQuery({
+    queryKey: ['reports'] as const,
+    queryFn: () => getReportList(),
+  });
+};
+
+export default useGetReportList;

--- a/src/apis/report/useModifyReportList.ts
+++ b/src/apis/report/useModifyReportList.ts
@@ -1,14 +1,18 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import client from '../core';
 
-export const modifyReportList = async (targetId: number, content: string) => {
+export const modifyReportList = async (
+  targetId: number | undefined,
+  content: string | undefined,
+) => {
+  if (typeof targetId === 'undefined') return;
   return await client.patch({
     url: `/reports/${targetId}`,
-    data: content,
+    data: { content: content },
   });
 };
 
-const useModifyReportlist = (targetId: number, content: string) => {
+const useModifyReportlist = (targetId: number | undefined, content: string | undefined) => {
   const queryClient = useQueryClient();
 
   const { mutate, ...rest } = useMutation({

--- a/src/apis/report/useModifyReportList.ts
+++ b/src/apis/report/useModifyReportList.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import client from '../core';
+
+export const modifyReportList = async (targetId: number, content: string) => {
+  return await client.patch({
+    url: `/reports/${targetId}`,
+    data: content,
+  });
+};
+
+const useModifyReportlist = (targetId: number, content: string) => {
+  const queryClient = useQueryClient();
+
+  const { mutate, ...rest } = useMutation({
+    mutationFn: () => modifyReportList(targetId, content),
+    onSuccess() {
+      queryClient.invalidateQueries({ queryKey: ['reports'] });
+    },
+  });
+
+  return { modifyReportList: mutate, ...rest };
+};
+
+export default useModifyReportlist;

--- a/src/app/mypage/report-list/_components/ReportList.tsx
+++ b/src/app/mypage/report-list/_components/ReportList.tsx
@@ -4,7 +4,7 @@ import ReportListItem from './ReportListItem';
 
 interface ReportListProps {
   data: Report[];
-  onModifyBtnClick: (id: number) => void;
+  onModifyBtnClick: (id: number, content: string) => void;
   onDeleteBtnClick: (id: number) => void;
 }
 

--- a/src/app/mypage/report-list/_components/ReportList.tsx
+++ b/src/app/mypage/report-list/_components/ReportList.tsx
@@ -1,5 +1,6 @@
+import { Report } from '@/types/report';
 import { Separator } from '@radix-ui/react-separator';
-import ReportListItem, { Report } from './ReportListItem';
+import ReportListItem from './ReportListItem';
 
 interface ReportListProps {
   data: Report[];

--- a/src/app/mypage/report-list/_components/ReportListItem.tsx
+++ b/src/app/mypage/report-list/_components/ReportListItem.tsx
@@ -1,12 +1,5 @@
 import { Button } from '@/components/ui/button';
-
-export interface Report {
-  reportId: number;
-  reporterId: number;
-  reportedId: number;
-  reportedNickname: string;
-  content: string;
-}
+import { Report } from '@/types/report';
 
 interface ReportListItemProps {
   data: Report;

--- a/src/app/mypage/report-list/_components/ReportListItem.tsx
+++ b/src/app/mypage/report-list/_components/ReportListItem.tsx
@@ -3,7 +3,7 @@ import { Report } from '@/types/report';
 
 interface ReportListItemProps {
   data: Report;
-  onModifyBtnClick: (id: number) => void;
+  onModifyBtnClick: (id: number, content: string) => void;
   onDeleteBtnClick: (id: number) => void;
 }
 
@@ -18,7 +18,7 @@ const ReportListItem = ({ data, onModifyBtnClick, onDeleteBtnClick }: ReportList
             variant="outline"
             className="border-1pxr h-30pxr w-50pxr border-solid border-main-1 text-xs text-main-1 hover:border-hover hover:bg-white hover:text-hover"
             onClick={() => {
-              onModifyBtnClick(data.reportId);
+              onModifyBtnClick(data.reportId, data.content);
             }}
           >
             수정

--- a/src/app/mypage/report-list/_components/ReportModifyModal.tsx
+++ b/src/app/mypage/report-list/_components/ReportModifyModal.tsx
@@ -1,0 +1,100 @@
+import { useEffect } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import Modal from '@/app/_components/Modal';
+import { Button } from '@/components/ui/button';
+import { CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Textarea } from '@/components/ui/textarea';
+import { useThunderModalStore } from '@/store/thunderModalStore';
+
+interface ReportModifyForm {
+  content: string;
+}
+
+interface ReportModifyModalProps {
+  defaultContent: string;
+  setContent: (content: string) => void;
+  completeModify: () => void;
+}
+
+const ReportModifyModal = ({
+  defaultContent,
+  setContent,
+  completeModify,
+}: ReportModifyModalProps) => {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    setFocus,
+    formState: { errors },
+  } = useForm<ReportModifyForm>({
+    mode: 'onSubmit',
+    defaultValues: {
+      content: defaultContent,
+    },
+  });
+
+  useEffect(() => {
+    reset({ content: defaultContent });
+  }, [defaultContent, reset]);
+
+  useEffect(() => {
+    setFocus('content');
+  }, [setFocus]);
+
+  const { isOpen, toggleModal } = useThunderModalStore();
+
+  const handleCloseModal = () => {
+    reset();
+    toggleModal();
+  };
+
+  const onSubmit: SubmitHandler<ReportModifyForm> = async ({ content }: ReportModifyForm) => {
+    setContent(content);
+    handleCloseModal();
+    completeModify();
+  };
+
+  return (
+    <>
+      <Modal
+        isOpen={isOpen}
+        onClose={handleCloseModal}
+      >
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <CardHeader>
+            <CardTitle className="text-lg">신고 내용 수정</CardTitle>
+          </CardHeader>
+          <CardContent className="flex-col">
+            <Textarea
+              className="w-full resize-none rounded-lg border p-10pxr text-sm focus:outline-none"
+              {...register('content', {
+                required: true,
+              })}
+              defaultValue={defaultContent}
+            />
+            {errors.content && <span className="text-sm text-red-1">내용을 입력해야 합니다.</span>}
+          </CardContent>
+          <CardFooter className="flex justify-between">
+            <Button
+              type="button"
+              onClick={handleCloseModal}
+              variant="outline"
+              className="border-1pxr w-120pxr border-solid border-main-1 text-main-1 hover:border-hover hover:bg-white hover:text-hover"
+            >
+              취소
+            </Button>
+            <Button
+              type="submit"
+              className="w-120pxr bg-main-1 hover:bg-hover"
+            >
+              생성
+            </Button>
+          </CardFooter>
+        </form>
+      </Modal>
+    </>
+  );
+};
+
+export default ReportModifyModal;

--- a/src/app/mypage/report-list/page.tsx
+++ b/src/app/mypage/report-list/page.tsx
@@ -1,57 +1,51 @@
 'use client';
 
+import { useState } from 'react';
+import useDeleteReportlist from '@/apis/report/useDeleteReportList';
+import useGetReportList from '@/apis/report/useGetReportList';
+import useModifyReportlist from '@/apis/report/useModifyReportList';
+import { useThunderModalStore } from '@/store/thunderModalStore';
 import ReportList from './_components/ReportList';
-
-const data = [
-  {
-    reportId: 1,
-    reporterId: 1,
-    reportedId: 3,
-    reportedNickname: '김춘식',
-    content:
-      '안녕하세요, 스토브 입니다. 개인정보 유효기간제 폐지(개정 전 개인정보보호법 제39조의 6)에 따라 휴면으로 분류되었던 회원님의 계정이 활성계정으로 전환될 예정입니다.',
-  },
-  {
-    reportId: 2,
-    reporterId: 1,
-    reportedId: 4,
-    reportedNickname: '김춘배',
-    content:
-      '안녕하세요, 스토브 입니다. 개인정보 유효기간제 폐지(개정 전 개인정보보호법 제39조의 6)에 따라 휴면으로 분류되었던 회원님의 계정이 활성계정으로 전환될 예정입니다.',
-  },
-  {
-    reportId: 3,
-    reporterId: 1,
-    reportedId: 5,
-    reportedNickname: '김민돌',
-    content:
-      '안녕하세요, 스토브 입니다. 개인정보 유효기간제 폐지(개정 전 개인정보보호법 제39조의 6)에 따라 휴면으로 분류되었던 회원님의 계정이 활성계정으로 전환될 예정입니다.',
-  },
-  {
-    reportId: 4,
-    reporterId: 1,
-    reportedId: 6,
-    reportedNickname: '김시리',
-    content:
-      '안녕하세요, 스토브 입니다. 개인정보 유효기간제 폐지(개정 전 개인정보보호법 제39조의 6)에 따라 휴면으로 분류되었던 회원님의 계정이 활성계정으로 전환될 예정입니다.',
-  },
-];
+import ReportModifyModal from './_components/ReportModifyModal';
 
 const ReportPage = () => {
-  const handleModifyButtonClick = (targetId: number) => {
-    console.log(`신고번호 ${targetId}를 수정합니다.`);
+  const [targetId, setTargetId] = useState<number | undefined>(undefined);
+  const [content, setContent] = useState<string>('');
+
+  const { toggleModal } = useThunderModalStore();
+
+  const { data } = useGetReportList();
+  const { deleteReportList } = useDeleteReportlist(targetId);
+  const { modifyReportList } = useModifyReportlist(targetId, content);
+
+  const handleModifyButtonClick = (targetId: number, defaultContent: string) => {
+    setTargetId(targetId);
+    setContent(defaultContent);
+    toggleModal();
   };
 
   const handleDeleteButtonClick = (targetId: number) => {
-    console.log(`신고번호 ${targetId}를 삭제합니다.`);
+    setTargetId(targetId);
+    deleteReportList();
+  };
+
+  const completeModify = () => {
+    modifyReportList();
   };
 
   return (
-    <ReportList
-      data={data}
-      onModifyBtnClick={handleModifyButtonClick}
-      onDeleteBtnClick={handleDeleteButtonClick}
-    />
+    <>
+      <ReportList
+        data={data ?? []}
+        onModifyBtnClick={handleModifyButtonClick}
+        onDeleteBtnClick={handleDeleteButtonClick}
+      />
+      <ReportModifyModal
+        defaultContent={content}
+        setContent={setContent}
+        completeModify={completeModify}
+      />
+    </>
   );
 };
 

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -1,0 +1,7 @@
+export interface Report {
+  reportId: number;
+  reporterId: number;
+  reportedId: number;
+  reportedNickname: string;
+  content: string;
+}


### PR DESCRIPTION
# [#79] 마이페이지 신고 목록 API 연결

## 📝 주요 작업 내용
- 마이페이지의 신고 목록의 API를 연결했습니다.
- 신고 목록 가져오기, 수정, 삭제가 가능합니다.

## 📷 스크린샷 (선택)

https://github.com/jae-hun-e/LocoMoco/assets/62047243/acd08075-89e1-403a-8b07-c06d8390ce37



## 💬 고민 중인 부분 및 참고사항 (선택)
- 수정 버튼 클릭 시 띄워진 모달의 textarea에 자동으로 focus가 가게 하고싶은데.. react hook form의 setFocus가 적용되질 않네요

close #79 

