### PR TITLE
[#87] 다른 유저 상세 페이지 api 연결

### DIFF
--- a/src/apis/review/useGetReceivedReviewSummary.ts
+++ b/src/apis/review/useGetReceivedReviewSummary.ts
@@ -30,7 +30,7 @@ export const useGetReceivedReviewSummary = (userId: number, reviews?: Reviews[])
           },
           select: (userInfo: UserInfo): ReviewSummary => {
             const { reviewId, reviewContentId, content, score, createdAt } = review;
-            const { nickname, job, profileImage } = userInfo;
+            const { nickname, job, profileImage } = userInfo.userInfo;
 
             return {
               userId,

--- a/src/apis/review/useGetSentReviewSummary.ts
+++ b/src/apis/review/useGetSentReviewSummary.ts
@@ -30,7 +30,7 @@ export const useGetSentReviewSummary = (userId: number, reviews?: Reviews[]) => 
           },
           select: (userInfo: UserInfo): ReviewSummary => {
             const { reviewId, reviewContentId, content, score, createdAt } = review;
-            const { nickname, job, profileImage } = userInfo;
+            const { nickname, job, profileImage } = userInfo.userInfo;
 
             return {
               userId,

--- a/src/apis/user/queryFn.ts
+++ b/src/apis/user/queryFn.ts
@@ -1,0 +1,14 @@
+import { MGCSummary } from '@/types/MGCList';
+import client from '../core';
+
+export const getOngoingMGCByUserId = async (userId: string) => {
+  return client.get<MGCSummary[]>({
+    url: `users/${userId}/mogakko/ongoing`,
+  });
+};
+
+export const getCompleteMGCByUserId = async (userId: string) => {
+  return client.get<MGCSummary[]>({
+    url: `users/${userId}/mogakko/complete`,
+  });
+};

--- a/src/apis/user/useGetJoinMGCByUserId.ts
+++ b/src/apis/user/useGetJoinMGCByUserId.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { getCompleteMGCByUserId, getOngoingMGCByUserId } from './queryFn';
+
+const useGetJoinMGCByUserId = (userId: string) => {
+  return useQuery({
+    queryKey: ['joinMGC', userId] as const,
+    queryFn: async () => {
+      const mgcResults = await Promise.all([
+        getOngoingMGCByUserId(userId),
+        getCompleteMGCByUserId(userId),
+      ]);
+      const flatMGCResults = mgcResults.flat();
+
+      return flatMGCResults;
+    },
+    enabled: !!userId,
+  });
+};
+
+export default useGetJoinMGCByUserId;

--- a/src/apis/user/useGetUserInfo.ts
+++ b/src/apis/user/useGetUserInfo.ts
@@ -2,18 +2,23 @@ import client from '@/apis/core';
 import { useQuery } from '@tanstack/react-query';
 
 export interface UserInfo {
-  userId: number;
-  nickname: string;
-  birth: string;
-  gender: 'FEMALE' | 'MALE';
-  temperature: number;
-  job: 'DEVELOPER' | 'JOB_SEEKER' | 'ETC';
-  email: string;
-  provider: 'KAKAO' | 'GITHUB';
-  profileImage: {
-    imageId: number;
-    path: string;
-  } | null;
+  userInfo: {
+    userId: number;
+    nickname: string;
+    birth: string;
+    gender: 'FEMALE' | 'MALE';
+    temperature: number;
+    job: 'DEVELOPER' | 'JOB_SEEKER' | 'ETC';
+    email: string;
+    provider: 'KAKAO' | 'GITHUB';
+    profileImage: {
+      imageId: number;
+      path: string;
+    } | null;
+  };
+  completeMogakkoCount: number;
+  likeMogakkoCount: number;
+  ongoingMogakkoCount: number;
 }
 
 export const getUserInfo = async (userId: number) => {

--- a/src/apis/user/useGetUserInfo.ts
+++ b/src/apis/user/useGetUserInfo.ts
@@ -19,6 +19,8 @@ export interface UserInfo {
   completeMogakkoCount: number;
   likeMogakkoCount: number;
   ongoingMogakkoCount: number;
+  blackListCount: number;
+  reportListCount: number;
 }
 
 export const getUserInfo = async (userId: number) => {

--- a/src/app/_components/MGCList/MGCList.tsx
+++ b/src/app/_components/MGCList/MGCList.tsx
@@ -21,7 +21,7 @@ const MGCList = ({ data }: MGCListPropsType) => {
       </div>
     );
   } else {
-    return <div>검색 결과에 해당하는 모각코가 없습니다!</div>;
+    return <div>해당하는 모각코가 없습니다!</div>;
   }
 };
 

--- a/src/app/_components/UserProfileInfo.tsx
+++ b/src/app/_components/UserProfileInfo.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { UserInfo } from '@/apis/user/useGetUserInfo';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import Image from 'next/image';
 
@@ -8,28 +9,8 @@ interface UserProfileInfoProps {
   flexDirection?: 'row' | 'col';
 }
 
-interface UserInfo {
-  name: string;
-  profileImg: string;
-  nickname: string;
-  birth: string;
-  gender: boolean;
-  job: string;
-  temperature: number;
-
-  likeMGC?: string[];
-  currentJoinMGC?: string[];
-  endJoinMGC?: string[];
-
-  receivedReview?: string[];
-  sentReview?: string[];
-  reportList?: string[];
-
-  blackList?: string[];
-}
-
 const UserProfileInfo = ({ userInfo, children, flexDirection = 'row' }: UserProfileInfoProps) => {
-  const { nickname, gender, birth, temperature } = userInfo;
+  const { nickname, gender, birth, temperature } = userInfo.userInfo;
 
   return (
     <section className="my-5">

--- a/src/app/another/[userId]/(main)/page.tsx
+++ b/src/app/another/[userId]/(main)/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import useGetUserInfo from '@/apis/user/useGetUserInfo';
 import UserProfileInfo from '@/app/_components/UserProfileInfo';
 import { Separator } from '@/components/ui/separator';
 import { userInfoDummy } from '@/constants/mypageDummyData';
@@ -8,16 +9,23 @@ import { ChevronRightIcon } from 'lucide-react';
 import Link from 'next/link';
 
 const AnotherPage = ({ params }: { params: { userId: string } }) => {
+  const { data: userInfo } = useGetUserInfo(parseInt(params.userId));
+
+  // TODO: suspense 적용 후 더미 제거 [24.03.14]
+  const joinMGCCount = userInfo
+    ? userInfo.completeMogakkoCount + userInfo.ongoingMogakkoCount
+    : userInfoDummy.completeMogakkoCount + userInfoDummy.ongoingMogakkoCount;
+
   return (
     <div>
       <UserProfileInfo
-        userInfo={userInfoDummy}
+        userInfo={userInfo ?? userInfoDummy}
         flexDirection="col"
       />
       <section className="mb-10 mt-50pxr flex flex-col gap-4 font-bold">
         <section className="flex flex-col gap-3 text-sm ">
           <div className="flex justify-between">
-            <p>참여한 모각코 {userInfoDummy.currentJoinMGC?.length} 개</p>
+            <p>참여한 모각코 {joinMGCCount} 개</p>
             <Link href={`/another/${params.userId}/join-mgc`}>
               <ChevronRightIcon />
             </Link>

--- a/src/app/another/[userId]/join-mgc/page.tsx
+++ b/src/app/another/[userId]/join-mgc/page.tsx
@@ -1,13 +1,16 @@
+'use client';
+
+import useGetJoinMGCByUserId from '@/apis/user/useGetJoinMGCByUserId';
 import MGCList from '@/app/_components/MGCList/MGCList';
 
-const page = ({ params }: { params: { userId: string } }) => {
-  // TODO: api 연결 후 제거 [24.03.13]
-  console.log(params);
+const JoinPage = ({ params }: { params: { userId: string } }) => {
+  const { data } = useGetJoinMGCByUserId(params.userId);
 
+  // TODO: suspense 적용 후 더미 제거 [24.03.15]
   const dummy = [
     {
       id: 1,
-      title: '모각코',
+      title: '모각코111',
       views: 12,
       likeCount: 1,
       maxParticipants: 3,
@@ -20,8 +23,8 @@ const page = ({ params }: { params: { userId: string } }) => {
       tags: [240],
     },
     {
-      id: 1,
-      title: '모각코2',
+      id: 2,
+      title: '모각코2222',
       views: 12,
       likeCount: 1,
       maxParticipants: 3,
@@ -37,9 +40,9 @@ const page = ({ params }: { params: { userId: string } }) => {
 
   return (
     <div>
-      <MGCList data={dummy} />
+      <MGCList data={data ?? dummy} />
     </div>
   );
 };
 
-export default page;
+export default JoinPage;

--- a/src/app/another/[userId]/join-mgc/page.tsx
+++ b/src/app/another/[userId]/join-mgc/page.tsx
@@ -6,41 +6,9 @@ import MGCList from '@/app/_components/MGCList/MGCList';
 const JoinPage = ({ params }: { params: { userId: string } }) => {
   const { data } = useGetJoinMGCByUserId(params.userId);
 
-  // TODO: suspense 적용 후 더미 제거 [24.03.15]
-  const dummy = [
-    {
-      id: 1,
-      title: '모각코111',
-      views: 12,
-      likeCount: 1,
-      maxParticipants: 3,
-      curParticipants: 1,
-      location: {
-        address: '구로동',
-        latitude: 37.456,
-        longitude: 126.6768,
-      },
-      tags: [240],
-    },
-    {
-      id: 2,
-      title: '모각코2222',
-      views: 12,
-      likeCount: 1,
-      maxParticipants: 3,
-      curParticipants: 1,
-      location: {
-        address: '구로동',
-        latitude: 37.456,
-        longitude: 126.6768,
-      },
-      tags: [238, 241],
-    },
-  ];
-
   return (
     <div>
-      <MGCList data={data ?? dummy} />
+      <MGCList data={data ?? []} />
     </div>
   );
 };

--- a/src/app/chat/[id]/loading.tsx
+++ b/src/app/chat/[id]/loading.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ChatLoading = () => {
+  return <div>ChatLoading...</div>;
+};
+
+export default ChatLoading;

--- a/src/app/chat/_components/review/Review.tsx
+++ b/src/app/chat/_components/review/Review.tsx
@@ -29,7 +29,9 @@ const Review = () => {
   // TODO: revieweeId 받아와서 수정 [24.03.05]
   const revieweeId = 78;
 
-  const { data: userInfo } = useGetUserInfo(revieweeId);
+  const { data: userInfoData } = useGetUserInfo(revieweeId);
+
+  const userInfo = userInfoData?.userInfo;
 
   const {
     formState: { errors },

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -28,7 +28,6 @@ const MyPage = () => {
     {
       title: '받은 리뷰 평가',
       link: routes.receivedReviewsAssessment,
-      count: 0,
     },
     { title: '블랙리스트', link: routes.blackList, count: userInfoDummy.blackListCount || 0 },
     { title: '신고목록', link: routes.reportList, count: userInfoDummy.reportListCount || 0 },
@@ -61,7 +60,7 @@ const MyPage = () => {
           >
             <div className="flex justify-between">
               <p>
-                {title} {count}
+                {title} {count ?? ''}
               </p>
               <Link href={link}>
                 <ChevronRightIcon />

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -14,24 +14,24 @@ import UserProfileInfo from '../_components/UserProfileInfo';
  */
 const MyPage = () => {
   const myActivities = [
-    { title: '내가 찜한 모각코', link: routes.likeMGC, count: userInfoDummy.likeMGC?.length || 0 },
+    { title: '내가 찜한 모각코', link: routes.likeMGC, count: userInfoDummy.likeMogakkoCount || 0 },
     {
       title: '현재 참여중인 모각코',
       link: routes.currentJoinMGC,
-      count: userInfoDummy.currentJoinMGC?.length || 0,
+      count: userInfoDummy.ongoingMogakkoCount || 0,
     },
     {
       title: '종료된 모각코',
       link: routes.endJoinMGC,
-      count: userInfoDummy.endJoinMGC?.length || 0,
+      count: userInfoDummy.completeMogakkoCount || 0,
     },
     {
       title: '받은 리뷰 평가',
       link: routes.receivedReviewsAssessment,
-      count: userInfoDummy.receivedReview?.length || 0,
+      count: 0,
     },
-    { title: '블랙리스트', link: routes.blackList, count: userInfoDummy.blackList?.length || 0 },
-    { title: '신고목록', link: routes.reportList, count: userInfoDummy.reportList?.length || 0 },
+    { title: '블랙리스트', link: routes.blackList, count: userInfoDummy.blackListCount || 0 },
+    { title: '신고목록', link: routes.reportList, count: userInfoDummy.reportListCount || 0 },
   ];
 
   const manageMyInfo = [

--- a/src/constants/mypageDummyData.ts
+++ b/src/constants/mypageDummyData.ts
@@ -1,35 +1,34 @@
-interface UserInfo {
-  name: string;
-  profileImg: string;
-  nickname: string;
-  birth: string;
-  gender: boolean;
-  job: string;
-  temperature: number;
+import { UserInfo } from '@/apis/user/useGetUserInfo';
 
-  likeMGC?: string[];
-  currentJoinMGC?: string[];
-  endJoinMGC?: string[];
+const gender = {
+  FEMALE: 'FEMALE',
+  MALE: 'MALE',
+} as const;
 
-  receivedReview?: string[];
-  sentReview?: string[];
-  reportList?: string[];
+const job = {
+  JOB_SEEKER: 'JOB_SEEKER',
+  DEVELOPER: 'DEVELOPER',
+  ETC: 'ETC',
+} as const;
 
-  blackList?: string[];
-}
+const provider = {
+  KAKAO: 'KAKAO',
+  GITHUB: 'GITHUB',
+} as const;
 
 export const userInfoDummy: UserInfo = {
-  name: '조재훈',
-  profileImg: 'https://image.newsis.com/2023/07/12/NISI20230712_0001313626_web.jpg',
-  nickname: '냐옹',
-  birth: '1997-07-22',
-  gender: true,
-  job: '취준생',
-  temperature: 36.5,
-
-  likeMGC: ['7', '8', '9'],
-  currentJoinMGC: ['1', '2', '3'],
-  endJoinMGC: ['4', '5', '6'],
-
-  blackList: ['4', '5', '6'],
+  userInfo: {
+    userId: 78,
+    nickname: '닉네임',
+    birth: '2023-12-12',
+    gender: gender.FEMALE,
+    temperature: 39,
+    job: job.DEVELOPER,
+    email: 'naver.com',
+    provider: provider.KAKAO,
+    profileImage: null,
+  },
+  completeMogakkoCount: 3,
+  likeMogakkoCount: 2,
+  ongoingMogakkoCount: 1,
 };

--- a/src/constants/mypageDummyData.ts
+++ b/src/constants/mypageDummyData.ts
@@ -31,4 +31,7 @@ export const userInfoDummy: UserInfo = {
   completeMogakkoCount: 3,
   likeMogakkoCount: 2,
   ongoingMogakkoCount: 1,
+  // TODO: 백엔드와 합의 후 이름 변경 [24.03.15]
+  blackListCount: 1,
+  reportListCount: 3,
 };


### PR DESCRIPTION
## 📝 주요 작업 내용
- 다른 유저 상세 페이지 api 연결
  - 유저 정보 api 연결
  - 유저가 참여한 모각코 api 연결

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷 스크린샷 (선택)
- 유저 페이지
![유저 상세](https://github.com/jae-hun-e/LocoMoco/assets/66080362/528818e4-7926-440a-a163-c93ca4f8c4ee)

## 💬 고민 중인 부분 및 참고사항 (선택)
- 모각코 리스트를 여러곳에서 사용하기에 빈값일 때 안내문구를 "해당하는 모각코가 없습니다!" 로 변경했습니다. 문구를 각각 다르게 할지 이렇게 하나로 할지 여러분들은 어떤 게 더 좋으신가요??
- 현재 더미값을 넣어둬서 더미값이 떴다가 실제 값으로 변경되는데 추후에 스켈레톤 ui를 적용하고 수정하겠습니다!
- UserInfo의 타입을 서버에서 오는 것과 같이 변경했습니다.
- 종료된 모각코, 참여중인 모각코를 합쳐서 `참여한 모각코`를 만들었습니다. 이 과정에서 종료된 모각코 api, 참여중인 모각코 api 는 다른 곳에서 쓰일 것이기에 `queryFn.ts` 파일에 따로 빼뒀습니다

apis/user/queryFn.ts
```
export const getOngoingMGCByUserId = async (userId: string) => {
  return client.get<MGCSummary[]>({
    url: `users/${userId}/mogakko/ongoing`,
  });
};

export const getCompleteMGCByUserId = async (userId: string) => {
  return client.get<MGCSummary[]>({
    url: `users/${userId}/mogakko/complete`,
  });
};
```

close #87 

