### PR TITLE
[#94] 채팅 페이지 내 참여 목록 및 후기 작성을 위한 모달 기능 추가

### DIFF
--- a/src/apis/review/useCreateReview.ts
+++ b/src/apis/review/useCreateReview.ts
@@ -2,7 +2,7 @@ import client from '@/apis/core';
 import { useMutation } from '@tanstack/react-query';
 
 interface ReviewData {
-  MGCId: number;
+  MGCId: string;
   reviewerId: string;
   data: {
     revieweeId: number;

--- a/src/apis/review/useCreateReview.ts
+++ b/src/apis/review/useCreateReview.ts
@@ -1,4 +1,5 @@
 import client from '@/apis/core';
+import { toast } from '@/components/ui/use-toast';
 import { useMutation } from '@tanstack/react-query';
 
 interface ReviewData {
@@ -23,6 +24,16 @@ const createReview = async (reviewData: ReviewData) => {
 const useCreateReview = () => {
   return useMutation({
     mutationFn: createReview,
+    onSuccess() {
+      toast({
+        description: '후기를 작성이 완료되었습니다.',
+      });
+    },
+    onError() {
+      toast({
+        description: '오류가 발생했습니다. 다시 시도해주세요.',
+      });
+    },
   });
 };
 

--- a/src/app/_components/Modal.tsx
+++ b/src/app/_components/Modal.tsx
@@ -1,14 +1,18 @@
 import { RefObject } from 'react';
 import { Card } from '@/components/ui/card';
 import useClickAway from '@/hooks/useClickaway';
+import { cn } from '@/libs/utils';
 
 interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
   children: React.ReactNode;
+  width?: string;
+  height?: string;
+  rounded?: string;
 }
 
-const Modal = ({ isOpen, onClose, children }: ModalProps) => {
+const Modal = ({ isOpen, onClose, children, width, height, rounded }: ModalProps) => {
   const modalContentRef = useClickAway((e: MouseEvent | TouchEvent) => {
     const { innerHTML } = e.target as HTMLDivElement;
     if (innerHTML === '⚡번개 모각코') return;
@@ -22,7 +26,9 @@ const Modal = ({ isOpen, onClose, children }: ModalProps) => {
           <Card
             ref={modalContentRef as RefObject<HTMLDivElement>}
             id="modal-content"
-            className="z-100 relative w-310pxr rounded-lg opacity-100 shadow"
+            className={cn(
+              `z-100 relative w-310pxr opacity-100 shadow w-${width ?? '310pxr'} h-${height ?? 'auto'} rounded-${rounded ?? 'lg'}`,
+            )}
           >
             {children}
           </Card>

--- a/src/app/_components/header/Header.tsx
+++ b/src/app/_components/header/Header.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import HeaderLeft from '@/app/_components/header/HeaderLeft';
-import { MenuIcon, MoreVerticalIcon, ShareIcon } from 'lucide-react';
+import { MoreVerticalIcon, ShareIcon } from 'lucide-react';
+import MenuBtn from './MenuBtn';
 
 interface Props {
   readonly children?: ReactNode;
@@ -22,8 +23,13 @@ const Right = ({ children }: Props) => {
   return <div className="flex items-center gap-20pxr">{children}</div>;
 };
 
+interface ButtonProps {
+  onClick?: () => void;
+}
+
 // TODO: 안에 내용이 정해지면 수정[24/02/14]
-const Menu = () => <MenuIcon />;
+const Menu = (props: ButtonProps) => <MenuBtn {...props} />;
+
 const Share = () => <ShareIcon />;
 const Option = () => <MoreVerticalIcon />;
 

--- a/src/app/_components/header/MenuBtn.tsx
+++ b/src/app/_components/header/MenuBtn.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { MenuIcon } from 'lucide-react';
+
+const MenuBtn = (props: { onClick?: () => void }) => {
+  return (
+    <button
+      onClick={() => {
+        props.onClick?.();
+      }}
+    >
+      <MenuIcon />
+    </button>
+  );
+};
+
+export default MenuBtn;

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -2,13 +2,18 @@
 
 import { useEffect, useRef, useState } from 'react';
 import client from '@/apis/core';
+import Modal from '@/app/_components/Modal';
+import UserList from '@/app/_components/UserInfoAndButton/UserList';
 import ChatInput from '@/app/chat/_components/ChatInput';
 import Messages from '@/app/chat/_components/Messages';
 import { Button } from '@/components/ui/button';
+import { useThunderModalStore } from '@/store/thunderModalStore';
 import { getItem } from '@/utils/storage';
 import { Client } from '@stomp/stompjs';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { X } from 'lucide-react';
 import SockJS from 'sockjs-client';
+import Review from '../_components/review/Review';
 
 export interface ChatType {
   chatMessageId: number;
@@ -25,6 +30,9 @@ const ChatRoom = ({ params: { id } }: { params: { id: string } }) => {
   const [stop, setStop] = useState(false);
   const stomp = useRef<Client>(new Client());
   const input = useRef<HTMLTextAreaElement>(null);
+
+  const [isUserList, setIsUserList] = useState(true);
+  const [selectedUserId, setSelectedUserId] = useState(0);
 
   const fetchChats = async ({ pageParam }: { pageParam: number }) => {
     console.log('fetching chat...');
@@ -112,23 +120,91 @@ const ChatRoom = ({ params: { id } }: { params: { id: string } }) => {
     input.current!.value = '';
   };
 
+  const { isOpen, toggleModal } = useThunderModalStore();
+
+  const participants = [
+    {
+      userId: 1,
+      nickname: '사용자1',
+      profileImage: {
+        imageId: 1,
+        path: '/oh.png',
+      },
+    },
+    {
+      userId: 2,
+      nickname: '사용자2',
+      profileImage: {
+        imageId: 1,
+        path: '/oh.png',
+      },
+    },
+    {
+      userId: 3,
+      nickname: '사용자3',
+      profileImage: {
+        imageId: 1,
+        path: '/oh.png',
+      },
+    },
+  ];
+
+  const handleCloseModal = () => {
+    toggleModal();
+    setIsUserList(true);
+  };
+
+  const handleButtonClick = (targetId: number) => {
+    console.log(`${targetId}에게 후기를 보냅니다.`);
+    setSelectedUserId(targetId);
+    setIsUserList(false);
+  };
+
   return (
-    <section className="flex flex-col">
-      <Messages talks={talks} />
-      <ChatInput
-        ref={input}
-        sendMessage={sendMessage}
-      />
-      {hasNextPage && (
-        <Button
-          disabled={isFetchingNextPage}
-          className="absolute h-5 opacity-30"
-          onClick={() => fetchNextPage()}
+    <div>
+      <section className="flex flex-col">
+        <Messages talks={talks} />
+        <ChatInput
+          ref={input}
+          sendMessage={sendMessage}
+        />
+        {hasNextPage && (
+          <Button
+            disabled={isFetchingNextPage}
+            className="absolute h-5 opacity-30"
+            onClick={() => fetchNextPage()}
+          >
+            {isFetchingNextPage ? 'Loading' : '이전 대화 불러오기'}
+          </Button>
+        )}
+        <Modal
+          isOpen={isOpen}
+          onClose={handleCloseModal}
+          width="full"
+          height="full"
+          rounded="none"
         >
-          {isFetchingNextPage ? 'Loading' : '이전 대화 불러오기'}
-        </Button>
-      )}
-    </section>
+          <div className="p-20pxr">
+            <button onClick={handleCloseModal}>
+              <X />
+            </button>
+            {isUserList ? (
+              <UserList
+                data={participants}
+                onClick={handleButtonClick}
+                buttonName="후기 보내기"
+              />
+            ) : (
+              <Review
+                MGCId={id}
+                revieweeId={selectedUserId}
+                onCancel={() => setIsUserList(true)}
+              />
+            )}
+          </div>
+        </Modal>
+      </section>
+    </div>
   );
 };
 export default ChatRoom;

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import client from '@/apis/core';
+import { useGetMGCDetail } from '@/apis/mgc/useGetMGCDetail';
 import Modal from '@/app/_components/Modal';
 import UserList from '@/app/_components/UserInfoAndButton/UserList';
 import ChatInput from '@/app/chat/_components/ChatInput';
@@ -34,6 +35,9 @@ const ChatRoom = ({ params: { id } }: { params: { id: string } }) => {
 
   const [isUserList, setIsUserList] = useState(true);
   const [selectedUserId, setSelectedUserId] = useState(0);
+
+  // TODO: params에 들어갈 값 모각코id로 할지 회의 후 수정(현재 id는 모각코 id) [24.03.15]
+  const { mgcDetail } = useGetMGCDetail(parseInt(id, 10));
 
   const fetchChats = async ({ pageParam }: { pageParam: number }) => {
     console.log('fetching chat...');
@@ -110,40 +114,12 @@ const ChatRoom = ({ params: { id } }: { params: { id: string } }) => {
 
   const { isOpen, toggleModal } = useThunderModalStore();
 
-  const participants = [
-    {
-      userId: 1,
-      nickname: '사용자1',
-      profileImage: {
-        imageId: 1,
-        path: '/oh.png',
-      },
-    },
-    {
-      userId: 2,
-      nickname: '사용자2',
-      profileImage: {
-        imageId: 1,
-        path: '/oh.png',
-      },
-    },
-    {
-      userId: 3,
-      nickname: '사용자3',
-      profileImage: {
-        imageId: 1,
-        path: '/oh.png',
-      },
-    },
-  ];
-
   const handleCloseModal = () => {
     toggleModal();
     setIsUserList(true);
   };
 
   const handleButtonClick = (targetId: number) => {
-    console.log(`${targetId}에게 후기를 보냅니다.`);
     setSelectedUserId(targetId);
     setIsUserList(false);
   };
@@ -178,7 +154,7 @@ const ChatRoom = ({ params: { id } }: { params: { id: string } }) => {
             </button>
             {isUserList ? (
               <UserList
-                data={participants}
+                data={[...mgcDetail.participants, mgcDetail.creatorInfo]}
                 onClick={handleButtonClick}
                 buttonName="후기 보내기"
               />

--- a/src/app/chat/_components/review/Review.tsx
+++ b/src/app/chat/_components/review/Review.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import useCreateReview from '@/apis/review/useCreateReview';

--- a/src/app/chat/_components/review/Review.tsx
+++ b/src/app/chat/_components/review/Review.tsx
@@ -12,6 +12,12 @@ import Profile from './Profile';
 import Rating from './Rating';
 import ReviewContent from './ReviewContent';
 
+interface ReviewProps {
+  MGCId: string;
+  revieweeId: number;
+  onCancel: () => void;
+}
+
 export interface ReviewForm {
   score: number;
   blockDesired: boolean;
@@ -19,15 +25,11 @@ export interface ReviewForm {
   content: string;
 }
 
-const Review = () => {
+const Review = ({ MGCId, revieweeId, onCancel }: ReviewProps) => {
   const { mutate: createReview } = useCreateReview();
   const [selectedRating, setSelectedRating] = useState(0);
 
   const reviewerId = getItem<string>(localStorage, USER_ID_KEY);
-  // TODO: 후기 톡방으로부터 mogakkoId 받아와서 수정 [24.03.05]
-  const MGCId = 71;
-  // TODO: revieweeId 받아와서 수정 [24.03.05]
-  const revieweeId = 78;
 
   const { data: userInfo } = useGetUserInfo(revieweeId);
 
@@ -49,7 +51,7 @@ const Review = () => {
 
   const handleCancelClick = () => {
     reset();
-    // TODO: 모달에 뿌려줄 컴포넌트가 list인지 판별하는 state변경을 해야함 [24.02.20]
+    onCancel();
   };
 
   const onSubmit = (data: ReviewForm) => {
@@ -70,7 +72,7 @@ const Review = () => {
     };
 
     createReview(reviewData);
-    // TODO: 모달에 뿌려줄 컴포넌트가 list인지 판별하는 state변경을 해야함 [24.02.20]
+    onCancel();
   };
 
   const handleRatingChange = (rating: number) => {
@@ -130,18 +132,18 @@ const Review = () => {
               onDeselected={handleMultiDeselect}
               register={register}
             />
-            <div className="fixed bottom-0 z-50 flex w-[calc(100vw-2.5rem)] justify-between gap-20pxr bg-white py-15pxr">
-              <Button
-                type="button"
-                onClick={handleCancelClick}
-                className="grow border border-main-1 bg-layer-1 text-main-1 hover:bg-white hover:font-bold"
-              >
-                취소
-              </Button>
-              <Button className="grow bg-main-1 hover:bg-hover hover:font-bold">생성</Button>
-            </div>
           </>
         ) : null}
+        <div className="fixed bottom-0 z-50 flex w-[calc(100vw-2.5rem)] justify-between gap-20pxr bg-white py-15pxr">
+          <Button
+            type="button"
+            onClick={handleCancelClick}
+            className="grow border border-main-1 bg-layer-1 text-main-1 hover:bg-white hover:font-bold"
+          >
+            취소
+          </Button>
+          <Button className="grow bg-main-1 hover:bg-hover hover:font-bold">생성</Button>
+        </div>
       </div>
     </form>
   );

--- a/src/app/chat/_components/review/Review.tsx
+++ b/src/app/chat/_components/review/Review.tsx
@@ -134,7 +134,7 @@ const Review = ({ MGCId, revieweeId, onCancel }: ReviewProps) => {
             />
           </>
         ) : null}
-        <div className="fixed bottom-0 z-50 flex w-[calc(100vw-2.5rem)] justify-between gap-20pxr bg-white py-15pxr">
+        <div className="fixed bottom-0 left-0 z-50 flex w-full justify-between gap-20pxr bg-white px-20pxr py-15pxr">
           <Button
             type="button"
             onClick={handleCancelClick}

--- a/src/app/chat/layout.tsx
+++ b/src/app/chat/layout.tsx
@@ -1,16 +1,21 @@
+'use client';
+
 import { ReactNode } from 'react';
 import Header from '@/app/_components/header/Header';
+import { useThunderModalStore } from '@/store/thunderModalStore';
 
 const ChatLayout = ({
   children,
 }: Readonly<{
   children: ReactNode;
 }>) => {
+  const { toggleModal } = useThunderModalStore();
+
   return (
     <>
       <Header>
         <Header.Right>
-          <Header.Menu />
+          <Header.Menu onClick={() => toggleModal()} />
         </Header.Right>
       </Header>
       {children}


### PR DESCRIPTION
## 📝 주요 작업 내용
- 각 톡방페이지에서 해당 참여자 목록 모달 토글
  - Menu 컴포넌트를 버튼 컴포넌트로 변경
- 참여자 목록에서 후기 작성 화면으로 전환
  - isUserList 값을 토대로 참여자 목록과 후기화면 전환

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷 스크린샷 (선택)
![참여자목록후기](https://github.com/jae-hun-e/LocoMoco/assets/66080362/0e6eb391-4c1b-4f48-ba05-735b0e6de890)


## 💬 고민 중인 부분 및 참고사항 (선택)
- 현재는 chatPage에서 chatId를 params로 받아오는데 그렇게하면 모각코 참여리스트를 위한 MGCId값을 구하기 위한 api를 또 사용해야 합니다. 그래서 params를 `모각코 id를 받아오는 것으로 가정하고 작업했는데 이 방법 어떠신가요??
- `UserList.tsx`에서 data의 길이가 0일때 "신고 목록이 없습니다"라는 멘트는 한곳에서만 사용가능한 멘트라서 바꿔야할 거 같아서 아래 두가지 방법 중 어떤 방법이 좋을까요??
1. 공통되는 멘트로 바꾼다 (ex: 해당 사용자가 존재하지 않습니다)
2. props로 멘트를 받아온다

close #94 

