### PR TITLE
[#111] 비회원 처리 + 외부 이미지 설정 추가

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,11 @@
 /** @type {import('next').NextConfig} */
 import withPWAInit, { runtimeCaching } from '@ducanh2912/next-pwa';
+
 const nextConfig = {
-  reactStrictMode: false,
+  reactStrictMode: true,
+  images: {
+    domains: ["locomoco-image.s3.ap-northeast-2.amazonaws.com"], // 이곳에 에러에서 hostname 다음 따옴표에 오는 링크를 적으면 된다.
+  },
 };
 
 const withPWA = withPWAInit({

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,7 +2,6 @@
 import withPWAInit, { runtimeCaching } from '@ducanh2912/next-pwa';
 
 const nextConfig = {
-  reactStrictMode: true,
   images: {
     domains: ["locomoco-image.s3.ap-northeast-2.amazonaws.com"], // 이곳에 에러에서 hostname 다음 따옴표에 오는 링크를 적으면 된다.
   },

--- a/src/app/_components/header/Header.tsx
+++ b/src/app/_components/header/Header.tsx
@@ -10,9 +10,11 @@ interface Props {
 const HeaderContainer = ({ children }: Props) => {
   return (
     <>
-      <header className="fixed left-0 top-0 z-50 flex h-14 w-full items-center justify-between bg-layer-1">
-        <HeaderLeft />
-        {children}
+      <header className="fixed left-0 top-0 z-50 h-14 w-full  bg-layer-1">
+        <div className="mx-20pxr flex h-full items-center justify-between">
+          <HeaderLeft />
+          {children}
+        </div>
       </header>
       <div className="mb-14" />
     </>

--- a/src/app/_components/header/HeaderLeft.tsx
+++ b/src/app/_components/header/HeaderLeft.tsx
@@ -14,7 +14,7 @@ const HeaderLeft = () => {
   else title = titleMap[lastArray as keyof typeof titleMap];
 
   return (
-    <div className="flex items-center gap-25pxr">
+    <div className="flex items-center gap-25pxr ">
       <button onClick={() => router.back()}>
         <ChevronLeftIcon />
       </button>

--- a/src/app/mgc/[id]/_components/Inquiry.tsx
+++ b/src/app/mgc/[id]/_components/Inquiry.tsx
@@ -26,7 +26,7 @@ const Inquiry = ({ MGCId }: Props) => {
   };
 
   return (
-    <section className="mb-100pxr">
+    <section className="mb-150pxr">
       <div className="mb-20pxr flex gap-1">
         <b>문의</b>
         <p>{inquiries.length}</p>

--- a/src/app/mgc/[id]/_components/MGCApplyArea.tsx
+++ b/src/app/mgc/[id]/_components/MGCApplyArea.tsx
@@ -65,7 +65,7 @@ const MGCApplyArea = ({
   };
 
   return (
-    <section className="fixed bottom-0 z-50 w-[calc(100%-2.5rem)] bg-layer-1">
+    <section className="fixed bottom-50pxr z-50 w-[calc(100%-2.5rem)] bg-layer-1">
       <MainStyleButton
         content={
           isClose

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -3,6 +3,7 @@
 import client from '@/apis/core';
 import UserInfo from '@/app/mypage/_components/UserInfo';
 import { useMypageInfo } from '@/app/mypage/_hooks/useMypageInfo';
+import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { routes } from '@/constants/routeURL';
 import { getItem, removeItem } from '@/utils/storage';
@@ -71,9 +72,17 @@ const MyPage = () => {
   };
 
   // TODO: 로딩처리 스켈레톤 추가[24/03/15]
+
   if (!myInfo) {
-    return <div>로딩중...</div>;
+    return (
+      <div className="flex h-svh w-full items-center justify-center">
+        <Link href={routes.signin}>
+          <Button>회원가입 시에만 사용할 수 있습니다.</Button>
+        </Link>
+      </div>
+    );
   }
+
   const myActivities = [
     { title: '내가 찜한 모각코', link: routes.likeMGC, count: myInfo.likeMogakkoCount },
     {

--- a/src/constants/routeURL.ts
+++ b/src/constants/routeURL.ts
@@ -4,6 +4,7 @@ export const routes = {
   chat: '/chat',
   mgc: '/mgc',
   search: '/search',
+  signin: '/signin',
   mypage: '/mypage',
   changeMyInfo: '/mypage/change-my-info',
   likeMGC: '/mypage/like-mgc',
@@ -14,7 +15,6 @@ export const routes = {
   sendReviews: '/mypage/send-reviews',
   reportList: '/mypage/report-list',
   blackList: '/mypage/black-list',
-  logout: '/mypage/logout',
   withdrawal: '/mypage/withdrawal',
 } as const;
 


### PR DESCRIPTION
## 📝 주요 작업 내용

1. 비회원 마이페이지 접근시 로그인 페이지로 이동
2. 헤더 css 변경
3. 외부이미지 경로 next.config설정

## 📷 스크린샷
![image](https://github.com/jae-hun-e/LocoMoco/assets/76520477/519f76b3-39af-42b9-ba06-47cc745ea2d9)


close #111 

