### PR TITLE
[#116] 번개 모각코 tag 추가 및 생성 시 디테일 페이지로 이동

### DIFF
--- a/src/apis/thunderMGC/useCreateThunderMGC.ts
+++ b/src/apis/thunderMGC/useCreateThunderMGC.ts
@@ -1,18 +1,25 @@
 import client from '@/apis/core';
 import { CreateMGCReq } from '@/apis/mgc/queryFn';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+interface CreatThunderMGCRes {
+  id: number;
+}
 
 export const createThunderMGC = async (createThunderMGCReq: CreateMGCReq) => {
-  return await client.post({ url: '/mogakko/map', data: createThunderMGCReq });
+  return await client.post<CreatThunderMGCRes>({ url: '/mogakko/map', data: createThunderMGCReq });
 };
 
 export const useCreateThunderMGC = () => {
-  const queryClient = useQueryClient();
-
+  const router = useRouter();
   const { mutate, ...rest } = useMutation({
     mutationFn: createThunderMGC,
-    onSuccess() {
-      queryClient.invalidateQueries({ queryKey: ['totalSearchMGC'] });
+    onError: (error) => {
+      console.log('error', error);
+    },
+    onSuccess: ({ id }) => {
+      router.push(`/mgc/${id}`);
     },
   });
 

--- a/src/app/(home)/_components/ThunderModal/ThunderModal.tsx
+++ b/src/app/(home)/_components/ThunderModal/ThunderModal.tsx
@@ -86,10 +86,9 @@ const ThunderModal = () => {
       deadline: toKoreanTimeZone(endDate),
       maxParticipants: 10,
       content: title,
-      tags: [],
+      tags: [243],
     };
 
-    console.log(req);
     createThunderMGC(req);
     handleCloseModal();
   };


### PR DESCRIPTION
# [#116] 번개 모각코 tag 추가 및 생성 시 디테일 페이지로 이동

## 📝 주요 작업 내용
- 번개 모각코 tag를 추가해서 번개 모각코일 경우 번개 아이콘이 제목 앞에 붙도록 했습니다.
- 이제 모각코 생성 시 디테일 페이지로 이동합니다. 

## 📷 스크린샷 (선택)

## 💬 고민 중인 부분 및 참고사항 (선택)


close #116 

