### PR TITLE
[#137] 유저 페이지 연결 및 존재하지 않는 유저 처리

### DIFF
--- a/src/apis/review/useGetReceivedReviewSummary.ts
+++ b/src/apis/review/useGetReceivedReviewSummary.ts
@@ -30,7 +30,7 @@ export const useGetReceivedReviewSummary = (userId: number, reviews?: Reviews[])
           },
           select: (userInfo: UserInfo): ReviewSummary => {
             const { reviewId, reviewContentId, content, score, createdAt, reviewerId } = review;
-            const { nickname, job, profileImage } = userInfo.userInfo;
+            const { nickname, jobId, profileImage } = userInfo.userInfo;
 
             return {
               userId: reviewerId,
@@ -39,7 +39,7 @@ export const useGetReceivedReviewSummary = (userId: number, reviews?: Reviews[])
               content,
               score,
               nickname,
-              job,
+              jobId,
               profileImage,
               createdAt,
             };

--- a/src/apis/review/useGetReceivedReviewSummary.ts
+++ b/src/apis/review/useGetReceivedReviewSummary.ts
@@ -29,11 +29,11 @@ export const useGetReceivedReviewSummary = (userId: number, reviews?: Reviews[])
             return await getUserInfo(review.reviewerId);
           },
           select: (userInfo: UserInfo): ReviewSummary => {
-            const { reviewId, reviewContentId, content, score, createdAt } = review;
+            const { reviewId, reviewContentId, content, score, createdAt, reviewerId } = review;
             const { nickname, job, profileImage } = userInfo.userInfo;
 
             return {
-              userId,
+              userId: reviewerId,
               reviewId,
               reviewContentId,
               content,

--- a/src/apis/review/useGetSentReviewSummary.ts
+++ b/src/apis/review/useGetSentReviewSummary.ts
@@ -30,7 +30,7 @@ export const useGetSentReviewSummary = (userId: number, reviews?: Reviews[]) => 
           },
           select: (userInfo: UserInfo): ReviewSummary => {
             const { reviewId, reviewContentId, content, score, createdAt, revieweeId } = review;
-            const { nickname, job, profileImage } = userInfo.userInfo;
+            const { nickname, jobId, profileImage } = userInfo.userInfo;
 
             return {
               userId: revieweeId,
@@ -39,7 +39,7 @@ export const useGetSentReviewSummary = (userId: number, reviews?: Reviews[]) => 
               content,
               score,
               nickname,
-              job,
+              jobId,
               profileImage,
               createdAt,
             };

--- a/src/apis/review/useGetSentReviewSummary.ts
+++ b/src/apis/review/useGetSentReviewSummary.ts
@@ -29,11 +29,11 @@ export const useGetSentReviewSummary = (userId: number, reviews?: Reviews[]) => 
             return await getUserInfo(review.revieweeId);
           },
           select: (userInfo: UserInfo): ReviewSummary => {
-            const { reviewId, reviewContentId, content, score, createdAt } = review;
+            const { reviewId, reviewContentId, content, score, createdAt, revieweeId } = review;
             const { nickname, job, profileImage } = userInfo.userInfo;
 
             return {
-              userId,
+              userId: revieweeId,
               reviewId,
               reviewContentId,
               content,

--- a/src/apis/user/useGetUserInfo.ts
+++ b/src/apis/user/useGetUserInfo.ts
@@ -8,7 +8,7 @@ export interface UserInfo {
     birth: string;
     gender: 'FEMALE' | 'MALE';
     temperature: number;
-    job: 'DEVELOPER' | 'JOB_SEEKER' | 'ETC';
+    jobId: number;
     email: string;
     provider: 'KAKAO' | 'GITHUB';
     profileImage: {

--- a/src/apis/user/useGetUserInfo.ts
+++ b/src/apis/user/useGetUserInfo.ts
@@ -1,5 +1,5 @@
 import client from '@/apis/core';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 export interface UserInfo {
   userInfo: {
@@ -30,7 +30,7 @@ export const getUserInfo = async (userId: number) => {
 };
 
 const useGetUserInfo = (userId: number) => {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: ['userInfo', userId] as const,
     queryFn: () => getUserInfo(userId),
   });

--- a/src/app/_components/ProfileImg.tsx
+++ b/src/app/_components/ProfileImg.tsx
@@ -1,0 +1,31 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import Image from 'next/image';
+import Link from 'next/link';
+
+interface ProfileImg {
+  userId: number;
+  imgUrl?: string;
+}
+
+const ProfileImg = ({ userId, imgUrl }: ProfileImg) => {
+  return (
+    <Link href={`/another/${userId}`}>
+      <Avatar className="h-32pxr w-32pxr rounded-full ">
+        <AvatarImage
+          src={imgUrl || 'https://github.com/shadcn.png'}
+          alt="유저 이미지"
+        />
+        <AvatarFallback>
+          <Image
+            src={'/oh.png'}
+            alt={'cn'}
+            width={32}
+            height={32}
+          />
+        </AvatarFallback>
+      </Avatar>
+    </Link>
+  );
+};
+
+export default ProfileImg;

--- a/src/app/_components/UserInfoAndButton/UserListItem.tsx
+++ b/src/app/_components/UserInfoAndButton/UserListItem.tsx
@@ -1,6 +1,6 @@
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { getItem } from '@/utils/storage';
+import ProfileImg from '../ProfileImg';
 
 export interface UserInfo {
   userId: number;
@@ -23,13 +23,10 @@ const UserListItem = ({ data, onClick, buttonName }: UserListItemProps) => {
   return (
     <li className="flex w-full items-center justify-between border-b border-solid py-14pxr">
       <div className="flex items-center gap-4">
-        <Avatar className="ml-1 rounded-3xl">
-          <AvatarImage
-            src={data.profileImage ? data.profileImage.path : '/oh.png'}
-            alt="프로필 사진"
-          />
-          <AvatarFallback>{data.nickname}</AvatarFallback>
-        </Avatar>
+        <ProfileImg
+          userId={data.userId}
+          imgUrl={data.profileImage?.path}
+        />
         <p>{data.nickname}</p>
       </div>
 

--- a/src/app/_components/UserProfileInfo.tsx
+++ b/src/app/_components/UserProfileInfo.tsx
@@ -33,7 +33,7 @@ const UserProfileInfo = ({ userInfo, children, flexDirection = 'row' }: UserProf
           <div className="mx-auto flex flex-col justify-center">
             <p>닉네임 : {nickname}</p>
             <div className="flex gap-6">
-              <p>성별 : {gender ? '남성' : '여성'}</p>
+              <p>성별 : {gender === 'MALE' ? '남성' : '여성'}</p>
               <p>나이 : {new Date().getFullYear() - Number(birth.split('-')[0])}세</p>
             </div>
             <p>온도 : {temperature}</p>

--- a/src/app/_components/UserProfileInfo.tsx
+++ b/src/app/_components/UserProfileInfo.tsx
@@ -17,7 +17,7 @@ const UserProfileInfo = ({ userInfo, children, flexDirection = 'row' }: UserProf
       <div className={`flex gap-4 flex-${flexDirection} items-center`}>
         <Avatar className="h-100pxr w-100pxr rounded-full">
           <AvatarImage
-            src="https://github.com/shadcn.png"
+            src={userInfo.userInfo.profileImage?.path ?? 'https://github.com/shadcn.png'}
             alt="유저 이미지"
           />
           <AvatarFallback>

--- a/src/app/_components/UserProfileInfo.tsx
+++ b/src/app/_components/UserProfileInfo.tsx
@@ -10,14 +10,14 @@ interface UserProfileInfoProps {
 }
 
 const UserProfileInfo = ({ userInfo, children, flexDirection = 'row' }: UserProfileInfoProps) => {
-  const { nickname, gender, birth, temperature } = userInfo.userInfo;
+  const { nickname, gender, birth, temperature, profileImage } = userInfo.userInfo;
 
   return (
     <section className="my-5">
       <div className={`flex gap-4 flex-${flexDirection} items-center`}>
         <Avatar className="h-100pxr w-100pxr rounded-full">
           <AvatarImage
-            src={userInfo.userInfo.profileImage?.path ?? 'https://github.com/shadcn.png'}
+            src={profileImage?.path ?? 'https://github.com/shadcn.png'}
             alt="유저 이미지"
           />
           <AvatarFallback>

--- a/src/app/_components/reviewList/ReviewItem.tsx
+++ b/src/app/_components/reviewList/ReviewItem.tsx
@@ -11,7 +11,7 @@ interface ReviewItemProps {
 export interface UserInfoData {
   userId: number;
   nickname: string;
-  job: string;
+  jobId: number;
   profileImage: {
     imageId: number;
     path: string;

--- a/src/app/_components/reviewList/UserInfo.tsx
+++ b/src/app/_components/reviewList/UserInfo.tsx
@@ -6,41 +6,39 @@ import { UserInfoData } from './ReviewItem';
 
 const UserInfo = ({ userInfo }: { userInfo: UserInfoData }) => {
   return (
-    <>
-      <section className="my-10pxr">
-        <div className="flex items-center gap-2">
-          <ProfileImg
-            userId={userInfo.userId}
-            imgUrl={userInfo.profileImage?.path}
-          />
-          <div className="flex flex-col gap-3pxr">
-            <span className="mr-10pxr text-xs">{userInfo.nickname}</span>
-            <div className="flex items-center gap-2">
-              <div className="flex">
-                <StarList
-                  rating={userInfo.score}
-                  fisrtNumber={1}
-                  color="#58C694"
-                  size={15}
-                />
-                <StarList
-                  rating={5 - userInfo.score}
-                  fisrtNumber={userInfo.score + 1}
-                  color="#D9D9D9"
-                  size={15}
-                />
-              </div>
-              <span className="text-xs text-layer-6">
-                {formatDistance(new Date(userInfo.createdAt), new Date(), {
-                  addSuffix: true,
-                  locale: ko,
-                })}
-              </span>
+    <section className="my-10pxr">
+      <div className="flex items-center gap-2">
+        <ProfileImg
+          userId={userInfo.userId}
+          imgUrl={userInfo.profileImage?.path}
+        />
+        <div className="flex flex-col gap-3pxr">
+          <span className="mr-10pxr text-xs">{userInfo.nickname}</span>
+          <div className="flex items-center gap-2">
+            <div className="flex">
+              <StarList
+                rating={userInfo.score}
+                fisrtNumber={1}
+                color="#58C694"
+                size={15}
+              />
+              <StarList
+                rating={5 - userInfo.score}
+                fisrtNumber={userInfo.score + 1}
+                color="#D9D9D9"
+                size={15}
+              />
             </div>
+            <span className="text-xs text-layer-6">
+              {formatDistance(new Date(userInfo.createdAt), new Date(), {
+                addSuffix: true,
+                locale: ko,
+              })}
+            </span>
           </div>
         </div>
-      </section>
-    </>
+      </div>
+    </section>
   );
 };
 

--- a/src/app/_components/reviewList/UserInfo.tsx
+++ b/src/app/_components/reviewList/UserInfo.tsx
@@ -1,8 +1,7 @@
 import StarList from '@/app/chat/_components/review/StarList';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { formatDistance } from 'date-fns';
 import { ko } from 'date-fns/locale';
-import Image from 'next/image';
+import ProfileImg from '../ProfileImg';
 import { UserInfoData } from './ReviewItem';
 
 const UserInfo = ({ userInfo }: { userInfo: UserInfoData }) => {
@@ -10,20 +9,10 @@ const UserInfo = ({ userInfo }: { userInfo: UserInfoData }) => {
     <>
       <section className="my-10pxr">
         <div className="flex items-center gap-2">
-          <Avatar className="h-32pxr w-32pxr rounded-full ">
-            <AvatarImage
-              src={userInfo.profileImage?.path || 'https://github.com/shadcn.png'}
-              alt="유저 이미지"
-            />
-            <AvatarFallback>
-              <Image
-                src={'/oh.png'}
-                alt={'cn'}
-                width={32}
-                height={32}
-              />
-            </AvatarFallback>
-          </Avatar>
+          <ProfileImg
+            userId={userInfo.userId}
+            imgUrl={userInfo.profileImage?.path}
+          />
           <div className="flex flex-col gap-3pxr">
             <span className="mr-10pxr text-xs">{userInfo.nickname}</span>
             <div className="flex items-center gap-2">

--- a/src/app/another/[userId]/(main)/error.tsx
+++ b/src/app/another/[userId]/(main)/error.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+const Error = () => {
+  return <div>존재하지 않는 사용자입니다.</div>;
+};
+
+export default Error;

--- a/src/app/another/[userId]/(main)/loading.tsx
+++ b/src/app/another/[userId]/(main)/loading.tsx
@@ -1,0 +1,5 @@
+const Loading = () => {
+  return <div>로딩중....</div>;
+};
+
+export default Loading;

--- a/src/app/another/[userId]/(main)/page.tsx
+++ b/src/app/another/[userId]/(main)/page.tsx
@@ -5,22 +5,18 @@ import useGetUserInfo from '@/apis/user/useGetUserInfo';
 import UserProfileInfo from '@/app/_components/UserProfileInfo';
 import ReportCreateModal from '@/app/mgc/[id]/_components/ReportCreateModal';
 import { Separator } from '@/components/ui/separator';
-import { userInfoDummy } from '@/constants/mypageDummyData';
 import { ChevronRightIcon } from 'lucide-react';
 import Link from 'next/link';
 
 const AnotherPage = ({ params }: { params: { userId: string } }) => {
   const { data: userInfo } = useGetUserInfo(parseInt(params.userId));
 
-  // TODO: suspense 적용 후 더미 제거 [24.03.14]
-  const joinMGCCount = userInfo
-    ? userInfo.completeMogakkoCount + userInfo.ongoingMogakkoCount
-    : userInfoDummy.completeMogakkoCount + userInfoDummy.ongoingMogakkoCount;
+  const joinMGCCount = userInfo.completeMogakkoCount + userInfo.ongoingMogakkoCount;
 
   return (
     <div>
       <UserProfileInfo
-        userInfo={userInfo ?? userInfoDummy}
+        userInfo={userInfo}
         flexDirection="col"
       />
       <section className="mb-10 mt-50pxr flex flex-col gap-4 font-bold">

--- a/src/app/chat/_components/Message.tsx
+++ b/src/app/chat/_components/Message.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useEffect, useRef } from 'react';
+import ProfileImg from '@/app/_components/ProfileImg';
 import { ChatType } from '@/types/chat';
 import { format } from 'date-fns';
-import Image from 'next/image';
 
 interface Props {
   notMe: boolean;
@@ -12,7 +12,7 @@ interface Props {
 const Message = ({
   notMe,
   commonBorder,
-  talk: { chatMessageId, senderProfileImage, senderNickName, message, createdAt },
+  talk: { chatMessageId, senderProfileImage, senderNickName, message, createdAt, senderId },
 }: Props) => {
   const scroll = useRef<HTMLDivElement>(null);
 
@@ -55,13 +55,9 @@ const Message = ({
     >
       <div className="flex items-center gap-1">
         {notMe && (
-          <Image
-            className="h-8 w-8 rounded-3xl"
-            src={senderProfileImage || '/oh.png'}
-            alt="profile image"
-            width={32}
-            height={32}
-            priority
+          <ProfileImg
+            userId={senderId}
+            imgUrl={senderProfileImage!}
           />
         )}
         <p>{notMe && senderNickName}</p>

--- a/src/app/chat/_components/review/Profile.tsx
+++ b/src/app/chat/_components/review/Profile.tsx
@@ -1,29 +1,19 @@
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import Image from 'next/image';
+import ProfileImg from '@/app/_components/ProfileImg';
 
 interface PropfileProps {
   profileImg: string;
   nickname: string;
   job: string;
+  userId: number;
 }
 
-const Profile = ({ profileImg, nickname, job }: PropfileProps) => {
+const Profile = ({ profileImg, userId, nickname, job }: PropfileProps) => {
   return (
     <div className="border-layout-3 flex gap-11pxr border-b border-solid py-10pxr">
-      <Avatar className="h-32pxr w-32pxr rounded-full ">
-        <AvatarImage
-          src={profileImg}
-          alt="profile image"
-        />
-        <AvatarFallback>
-          <Image
-            src={'/oh.png'}
-            alt={'cn'}
-            width={32}
-            height={32}
-          />
-        </AvatarFallback>
-      </Avatar>
+      <ProfileImg
+        userId={userId}
+        imgUrl={profileImg}
+      />
 
       <div className="flex flex-col gap-3pxr text-sm">
         <p>{nickname}</p>

--- a/src/app/chat/_components/review/Review.tsx
+++ b/src/app/chat/_components/review/Review.tsx
@@ -4,7 +4,7 @@ import useCreateReview from '@/apis/review/useCreateReview';
 import useGetUserInfo from '@/apis/user/useGetUserInfo';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/use-toast';
-import { job } from '@/constants/userInfo';
+import { useTagMapping } from '@/hooks/useTagMapping';
 import { USER_ID_KEY, getItem } from '@/utils/storage';
 import Profile from './Profile';
 import Rating from './Rating';
@@ -33,6 +33,8 @@ const Review = ({ MGCId, revieweeId, onCancel, isEnd }: ReviewProps) => {
   const { data: userInfoData } = useGetUserInfo(revieweeId);
 
   const userInfo = userInfoData?.userInfo;
+
+  const tagMapping = useTagMapping();
 
   useEffect(() => {
     if (!isEnd) {
@@ -118,9 +120,10 @@ const Review = ({ MGCId, revieweeId, onCancel, isEnd }: ReviewProps) => {
     <form onSubmit={handleSubmit(onSubmit)}>
       <div className="relative flex h-full flex-col gap-30pxr pb-50pxr">
         <Profile
+          userId={userInfo.userId}
           profileImg={userInfo?.profileImage?.path ?? ''}
           nickname={userInfo?.nickname ?? ''}
-          job={userInfo?.job ? job[userInfo?.job] : ''}
+          job={tagMapping.get(userInfo.jobId)?.tagName ?? ''}
         />
 
         <Rating

--- a/src/app/mgc/[id]/_components/AuthorInfo.tsx
+++ b/src/app/mgc/[id]/_components/AuthorInfo.tsx
@@ -1,8 +1,7 @@
 import { UserInfo } from '@/apis/mgc/useGetMGCDetail';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import ProfileImg from '@/app/_components/ProfileImg';
 import { formatDistance } from 'date-fns';
 import { ko } from 'date-fns/locale';
-import Image from 'next/image';
 
 interface Props {
   author: UserInfo;
@@ -10,24 +9,18 @@ interface Props {
   createdAt: string;
   updatedAt: string;
 }
-const AuthorInfo = ({ author: { nickname, profileImage }, hits, createdAt, updatedAt }: Props) => {
+const AuthorInfo = ({
+  author: { nickname, profileImage, userId },
+  hits,
+  createdAt,
+  updatedAt,
+}: Props) => {
   return (
     <section className="my-10pxr flex gap-11pxr">
-      <Avatar className="h-32pxr w-32pxr rounded-full ">
-        <AvatarImage
-          src={profileImage?.path || 'https://github.com/shadcn.png'}
-          alt="유저 이미지"
-        />
-        <AvatarFallback>
-          <Image
-            src={'/oh.png'}
-            alt={'cn'}
-            width={32}
-            height={32}
-          />
-        </AvatarFallback>
-      </Avatar>
-
+      <ProfileImg
+        userId={userId}
+        imgUrl={profileImage?.path}
+      />
       <div className="flex flex-col gap-3pxr">
         <p>{nickname}</p>
         <p className="font-extralight">

--- a/src/app/mgc/[id]/_components/MGCParticipants.tsx
+++ b/src/app/mgc/[id]/_components/MGCParticipants.tsx
@@ -1,6 +1,5 @@
 import { UserInfo } from '@/apis/mgc/useGetMGCDetail';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import Image from 'next/image';
+import ProfileImg from '@/app/_components/ProfileImg';
 
 interface Props {
   joinUsers: UserInfo[];
@@ -18,20 +17,10 @@ const MGCParticipants = ({ joinUsers }: Props) => {
               key={userId}
               className="flex flex-col items-center justify-center"
             >
-              <Avatar className="h-32pxr w-32pxr rounded-full ">
-                <AvatarImage
-                  src={profileImage?.path || 'https://github.com/shadcn.png'}
-                  alt="참가자 정보"
-                />
-                <AvatarFallback>
-                  <Image
-                    src={'/oh.png'}
-                    alt={'cn'}
-                    width={32}
-                    height={32}
-                  />
-                </AvatarFallback>
-              </Avatar>
+              <ProfileImg
+                userId={userId}
+                imgUrl={profileImage?.path}
+              />
               <p className="text-sm">{nickname}</p>
             </div>
           ))

--- a/src/constants/mypageDummyData.ts
+++ b/src/constants/mypageDummyData.ts
@@ -5,12 +5,6 @@ const gender = {
   MALE: 'MALE',
 } as const;
 
-const job = {
-  JOB_SEEKER: 'JOB_SEEKER',
-  DEVELOPER: 'DEVELOPER',
-  ETC: 'ETC',
-} as const;
-
 const provider = {
   KAKAO: 'KAKAO',
   GITHUB: 'GITHUB',
@@ -23,7 +17,7 @@ export const userInfoDummy: UserInfo = {
     birth: '2023-12-12',
     gender: gender.FEMALE,
     temperature: 39,
-    job: job.DEVELOPER,
+    jobId: 241,
     email: 'naver.com',
     provider: provider.KAKAO,
     profileImage: null,

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -4,7 +4,7 @@ export interface ReviewSummary {
   content: string;
   userId: number;
   nickname: string;
-  job: string;
+  jobId: number;
   profileImage: {
     imageId: number;
     path: string;


### PR DESCRIPTION
## 📝 주요 작업 내용
- 유저 페이지 연결
- 존재하지 않는 유저페이지 접근 시 처리
  -  suspense처리를 해서 없는 경우 바로 에러를 띄우고 error.tsx에서 잡는 식으로 구현했습니다.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷 스크린샷 (선택)
- 존재하지 않는 사용자 화면
![image](https://github.com/jae-hun-e/LocoMoco/assets/66080362/5e017936-b058-4795-a820-8a26c80dc10d)

## 💬 고민 중인 부분 및 참고사항 (선택)
- 에러처리에 관한 ui가 정해지지 않아 임시로 안내글만 적어뒀습니다.
- 일단 프로필 이미지가 있는 부분을 다 연결해 두었는데 추가로 연결할 부분이 있다면 알려주세요!
- 현재 모달을 켜고 끄는 변수를 하나의 store에 저장해두기 때문에 a페이지에서 모달이 켜져있는 상태에서 b 페이지로 이동 시 b페이지의 모달이 켜져있는 버그가 발생합니다. 
  - 모달을 제어하는 기능을 hook으로 빼서 ui따로 해당 모달을 제어하는 기능따로 하면 해결 될 거 같습니다!
![image](https://github.com/jae-hun-e/LocoMoco/assets/66080362/118c1825-baa8-4361-b9d7-5bd37161224b)

close #137  
