### PR TITLE
[#156] 모바일에서 인포윈도우 닫을 시  닫힘 버튼 위치로 이동되는 문제 해결

### DIFF
--- a/src/app/(home)/_components/Map.tsx
+++ b/src/app/(home)/_components/Map.tsx
@@ -78,6 +78,10 @@ const Map = forwardRef(
 
     const handleTouchStart = useCallback(
       (e: TouchEvent) => {
+        const target = e.target as HTMLElement;
+
+        if (target.closest('#infowindow')) return;
+
         if (!(e.target instanceof SVGElement)) return;
 
         if (map) {


### PR DESCRIPTION
## 📝 주요 작업 내용
- 모바일에서 인포윈도우 닫을 시  닫힘 버튼 위치로 이동되는 문제 해결
  - 원인: 닫힘 버튼의 아이콘도 SVGElement라서 지도를 누른것과 같은 동작이 발생
  - 해결: 모달안의 요소를 선택하지 못하도록 수정
  
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷 스크린샷 (선택)
- 해결 전
![GIF 2024-04-14 오전 12-04-03](https://github.com/jae-hun-e/LocoMoco/assets/66080362/67229834-a074-4195-94c1-85b0dd141477)

- 해결 후
![GIF 2024-04-14 오전 12-05-12](https://github.com/jae-hun-e/LocoMoco/assets/66080362/dad440a3-90cf-436e-ba7d-f8383721cbd8)

## 💬 고민 중인 부분 및 참고사항 (선택)


close #156 

