### PR TITLE
[#181] 모각코 생성시 버그 수정

### DIFF
--- a/src/app/_components/Map/MGCMap.tsx
+++ b/src/app/_components/Map/MGCMap.tsx
@@ -38,21 +38,24 @@ const MGCMap = ({ trigger, setValue, defaultAddress }: Props) => {
       setAddress(defaultAddress?.address ?? '');
     }
   }, [currentAddress, defaultAddress?.address]);
+
   const [currentCoordinates, setCurrentCoordinates] = useState({ latitude: 0, longitude: 0 });
 
   const updateAddress = ({
     newAddress,
-    latLng,
+    latitude,
+    longitude,
   }: {
     newAddress: string;
-    latLng: kakao.maps.LatLng;
+    latitude: number;
+    longitude: number;
   }) => {
     setAddress(newAddress);
     const assertedSetValue = setValue as UseFormSetValue<MGCCreateForm | ThunderFormData>;
 
     assertedSetValue('location.address', newAddress);
-    assertedSetValue('location.latitude', latLng.getLat());
-    assertedSetValue('location.longitude', latLng.getLng());
+    assertedSetValue('location.latitude', latitude);
+    assertedSetValue('location.longitude', longitude);
     assertedSetValue('location.city', newAddress);
     trigger('location');
   };
@@ -72,6 +75,7 @@ const MGCMap = ({ trigger, setValue, defaultAddress }: Props) => {
             defaultAddress={defaultAddress}
           />
           <CreateMGCMapViewer
+            defaultAddress={defaultAddress}
             updateAddress={updateAddress}
             setCurrentCoordinates={setCurrentCoordinates}
             onMouseUp={handleMouseUp}

--- a/src/app/create/_components/CreateMGC.tsx
+++ b/src/app/create/_components/CreateMGC.tsx
@@ -63,7 +63,9 @@ const CreateMGC = ({ initData, MGCId }: Props) => {
       date: initData?.startTime ? new Date(initData?.startTime) : undefined,
       startTime: initData?.startTime && getTimeString(initData?.startTime),
       endTime: initData?.endTime && getTimeString(initData?.endTime),
-      deadLine: initData?.endTime ? new Date(initData?.endTime) : undefined,
+      deadLine: initData?.endTime
+        ? new Date(new Date(initData?.endTime).setHours(0, 0, 0, 0))
+        : undefined,
       maxParticipants: initData?.maxParticipants ?? 10,
       content: initData?.content,
     },

--- a/src/app/create/_components/CreateMGC.tsx
+++ b/src/app/create/_components/CreateMGC.tsx
@@ -53,6 +53,8 @@ const CreateMGC = ({ initData, MGCId }: Props) => {
     formState: { errors, isValid },
     watch,
     trigger,
+    setError,
+    clearErrors,
   } = useForm<MGCCreateForm>({
     mode: 'onTouched',
     defaultValues: {
@@ -149,6 +151,8 @@ const CreateMGC = ({ initData, MGCId }: Props) => {
         setValue={setValue}
         trigger={trigger}
         watch={watch}
+        setError={setError}
+        clearErrors={clearErrors}
       />
 
       <OptionFields

--- a/src/app/create/_components/MGCTime.tsx
+++ b/src/app/create/_components/MGCTime.tsx
@@ -35,7 +35,7 @@ const MGCTime = ({ watch, register, errors, setError, clearErrors }: Props) => {
   const validateTimes = (type: 'start' | 'end'): boolean | string => {
     if (!startTime || !endTime) return true;
 
-    const errorMessage = '종료시간은 시작시간보다 빨리 설정될 수 없습니다.';
+    const errorMessage = '종료시간은 시작시간보다 빠를 수 없습니다.';
     const startDate = parseTime(startTime);
     const endDate = parseTime(endTime);
 
@@ -78,7 +78,7 @@ const MGCTime = ({ watch, register, errors, setError, clearErrors }: Props) => {
               defaultValue={watch('startTime')}
             />
             {errors.startTime && (
-              <span className="absolute -bottom-5 text-xs text-red-1">
+              <span className="absolute bottom-0 translate-y-full text-xs text-red-1">
                 {errors.startTime.message}
               </span>
             )}
@@ -97,7 +97,7 @@ const MGCTime = ({ watch, register, errors, setError, clearErrors }: Props) => {
               defaultValue={watch('endTime')}
             />
             {errors.endTime && (
-              <span className="absolute -bottom-5 text-xs text-red-1">
+              <span className="absolute bottom-0 translate-y-full text-xs text-red-1">
                 {errors.endTime.message}
               </span>
             )}

--- a/src/app/create/_components/RequiredFields.tsx
+++ b/src/app/create/_components/RequiredFields.tsx
@@ -53,6 +53,30 @@ const RequiredFields = ({
     });
   }, []);
 
+  const date = watch('date');
+  const deadLine = watch('deadLine');
+
+  useEffect(() => {
+    const validateDates = () => {
+      if (!date || !deadLine) return true;
+
+      const errorMessage = '신청 마감일은 모각코 날짜보다 늦을 수 없습니다.';
+      const startDate = new Date(date);
+      const endDate = new Date(deadLine);
+
+      if (endDate > startDate) {
+        setError('deadLine', {
+          type: 'validate',
+          message: errorMessage,
+        });
+      } else {
+        clearErrors('deadLine');
+      }
+    };
+
+    validateDates();
+  }, [date, deadLine, setError, clearErrors]);
+
   return (
     <>
       <input

--- a/src/app/create/_components/RequiredFields.tsx
+++ b/src/app/create/_components/RequiredFields.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from 'react';
 import {
   FieldErrors,
+  UseFormClearErrors,
   UseFormRegister,
+  UseFormSetError,
   UseFormSetValue,
   UseFormTrigger,
   UseFormWatch,
@@ -19,8 +21,18 @@ interface Props {
   setValue: UseFormSetValue<MGCCreateForm>;
   trigger: UseFormTrigger<MGCCreateForm>;
   watch: UseFormWatch<MGCCreateForm>;
+  setError: UseFormSetError<MGCCreateForm>;
+  clearErrors: UseFormClearErrors<MGCCreateForm>;
 }
-const RequiredFields = ({ register, errors, setValue, trigger, watch }: Props) => {
+const RequiredFields = ({
+  register,
+  errors,
+  setValue,
+  trigger,
+  watch,
+  clearErrors,
+  setError,
+}: Props) => {
   const requiredFields: { field: keyof MGCCreateForm; message: string }[] = [
     { field: 'title', message: '제목을 입력해주세요.' },
     { field: 'date', message: '모각코 날짜를 선택해주세요.' },
@@ -32,11 +44,6 @@ const RequiredFields = ({ register, errors, setValue, trigger, watch }: Props) =
 
   const handleMGCDate = (field: keyof MGCCreateForm, selectedDay: Date) => {
     setValue(field, selectedDay);
-    trigger(field);
-  };
-
-  const handleMGCTime = (field: keyof MGCCreateForm, value: string) => {
-    setValue(field, value);
     trigger(field);
   };
 
@@ -81,10 +88,11 @@ const RequiredFields = ({ register, errors, setValue, trigger, watch }: Props) =
       />
 
       <MGCTime
-        onChangeInput={(field, selectedTime) => handleMGCTime(field, selectedTime)}
-        startErrormessage={errors.startTime?.message}
-        endErrormessage={errors.endTime?.message}
         watch={watch}
+        register={register}
+        errors={errors}
+        setError={setError}
+        clearErrors={clearErrors}
       />
 
       <MGCDate


### PR DESCRIPTION
## 📝 주요 작업 내용
- 유효하지 않은 종료 시간 선택 후 유효한 값으로 수정해도 경고 메시지가 떠있는 버그 해결
  - state로 관리되던 에러메시지 대신 register를 등록하고 validate를 추가하여 해결
  ```
  <Input
    id={startId}
    type="time"
    step="600"
    {...register('startTime', {
      validate: () => validateTimes('start'),
    })}
    className="w-100pxr text-xs"
    defaultValue={watch('startTime')}
  />
  ```
- 종료 시간을 앞당길 때 발생하는 생성 오류 수정
  - deadLine보다 늦은 시간일 시 발생하기에 기본값을 받아올때 00시00분으로 설정하여 해결 
- 생성 페이지에서 기본 위치값이 받아와지지 않는 문제 해결
  - 기본 주소가 없다면(=생성 페이지라면) 현재 위치로 값을 설정하여 해결
- 신청마감일 먼저 선택 시 모각코 날짜보다 뒤의 날짜도 선택 가능한 버그 해결
  - useEffect로 watch로 잡은 값이 변할 때마다 validate함수를 실행시켜서 해결
- 경고 메시지 UI 겹침 현상 수정

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷 스크린샷 (선택)
- ui 수정 전
![image](https://github.com/jae-hun-e/LocoMoco/assets/66080362/feac3389-5ef2-409b-9850-61d8b4f87ee9)

- ui 수정 후
![image](https://github.com/jae-hun-e/LocoMoco/assets/66080362/717b2674-b666-4ca3-b36a-4c98d168e565)


## 💬 고민 중인 부분 및 참고사항 (선택)


close #181 

