### PR TITLE
[#183] 홈페이지 통합테스트

### DIFF
--- a/src/app/(home)/_components/SearchBarFilter.tsx
+++ b/src/app/(home)/_components/SearchBarFilter.tsx
@@ -1,9 +1,11 @@
 import React, { useRef, useState } from 'react';
 import useAddress, { Address } from '@/apis/address/useAddressSearch';
 import Filter from '@/app/_components/filter/Filter';
+import { toast } from '@/components/ui/use-toast';
 import { metroGovernments } from '@/constants/metroGovernments';
 import useChangeMapCenter from '@/hooks/useChangeMapCenter';
 import useClickAway from '@/hooks/useClickaway';
+import useGetAddressByCoordinates from '@/hooks/useGetAddressByCoordinates';
 import useSearchInputValueStore from '@/store/useSearchValueStore';
 import { Search } from 'lucide-react';
 import AddressList from './AddressList';
@@ -21,20 +23,30 @@ const SearchBarFilter = () => {
 
   const { changeCenter } = useChangeMapCenter();
   const { searchValue, setSearchValue } = useSearchInputValueStore();
+  const { getAddressByCoorinates } = useGetAddressByCoordinates();
 
-  const changeAddress = async (addressName: string) => {
+  const changeAddress = async (latitude: number, longitude: number, addressName: string) => {
+    const address = await getAddressByCoorinates(latitude, longitude);
+
+    if (!address) {
+      toast({
+        description: '오류가 발생했습니다.',
+      });
+      return;
+    }
+
     const isIncluded = Object.keys(metroGovernments).includes(addressName);
 
     setSearchValue({
       ...searchValue,
-      address: isIncluded ? metroGovernments[addressName] : addressName,
+      address: isIncluded ? metroGovernments[addressName] : address,
     });
   };
 
   const handleAddressClick = (data: Address) => {
     const { latitude, longitude, addressName } = data;
     changeCenter(latitude, longitude);
-    changeAddress(addressName);
+    changeAddress(latitude, longitude, addressName);
     setShow(false);
   };
 

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import useMGCTotalList from '@/apis/mgcList/useMGCTotalList';
-import useSearchInputValueStore from '@/store/useSearchValueStore';
+import useSearchValueStore from '@/store/useSearchValueStore';
 import { MGCSummary } from '@/types/MGCList';
 import CreateBtn from '../_components/CreateBtn';
 import MGCList from '../_components/MGCList/MGCList';
@@ -18,11 +18,12 @@ const Home = () => {
 
   const mapRef = useRef<HTMLDivElement>(null);
 
-  const { searchValue } = useSearchInputValueStore();
+  const { searchValue } = useSearchValueStore();
 
   const { data } = useMGCTotalList({
     search: searchValue.address,
     searchType: 'LOCATION',
+    tags: searchValue.tags,
   });
 
   useEffect(() => {

--- a/src/app/_components/filter/Filter.tsx
+++ b/src/app/_components/filter/Filter.tsx
@@ -25,14 +25,20 @@ const Filter = () => {
           value="item-1"
           className="w-full"
         >
-          <AccordionTrigger className="p-0 hover:no-underline">
+          <AccordionTrigger
+            className="p-0 hover:no-underline"
+            aria-label="accordion trigger"
+          >
             <div className="flex w-full flex-row justify-between gap-1.5">
               <span>모각코 종류</span>
               <span>개발 언어</span>
               <span>공부 분야</span>
             </div>
           </AccordionTrigger>
-          <AccordionContent className="absolute left-0 z-10 flex w-full justify-center bg-white">
+          <AccordionContent
+            aria-label="accordion content"
+            className="absolute left-0 z-10 flex w-full justify-center bg-white"
+          >
             <FilterContent onSubmit={(data: SearchFilterForm) => handleSubmit(data)} />
           </AccordionContent>
         </AccordionItem>

--- a/src/constants/geocodeAddressConversion.ts
+++ b/src/constants/geocodeAddressConversion.ts
@@ -1,0 +1,66 @@
+interface RegionInfo {
+  region_type: string;
+  code: string;
+  address_name: string;
+  region_1depth_name: string;
+  region_2depth_name: string;
+  region_3depth_name: string;
+  region_4depth_name: string;
+  x: number;
+  y: number;
+}
+
+interface GeocodeAddressConversion {
+  [key: string]: RegionInfo[];
+}
+
+export const geocodeAddressConversion: GeocodeAddressConversion = {
+  '서울특별시 서초구 서초1동': [
+    {
+      region_type: 'B',
+      code: '1165010800',
+      address_name: '서울특별시 서초구 서초동',
+      region_1depth_name: '서울특별시',
+      region_2depth_name: '서초구',
+      region_3depth_name: '서초동',
+      region_4depth_name: '',
+      x: 127.01909121413102,
+      y: 37.4888536906029,
+    },
+    {
+      region_type: 'H',
+      code: '1165051000',
+      address_name: '서울특별시 서초구 서초1동',
+      region_1depth_name: '서울특별시',
+      region_2depth_name: '서초구',
+      region_3depth_name: '서초1동',
+      region_4depth_name: '',
+      x: 127.01957096253298,
+      y: 37.49007898260848,
+    },
+  ],
+  '경기도 성남시 분당구 판교동': [
+    {
+      region_type: 'B',
+      code: '4113510800',
+      address_name: '경기도 성남시 분당구 판교동',
+      region_1depth_name: '경기도',
+      region_2depth_name: '성남시 분당구',
+      region_3depth_name: '판교동',
+      region_4depth_name: '',
+      x: 127.09878136729033,
+      y: 37.38986806920579,
+    },
+    {
+      region_type: 'H',
+      code: '4113565000',
+      address_name: '경기도 성남시 분당구 판교동',
+      region_1depth_name: '경기도',
+      region_2depth_name: '성남시 분당구',
+      region_3depth_name: '판교동',
+      region_4depth_name: '',
+      x: 127.09878136729033,
+      y: 37.38986806920579,
+    },
+  ],
+};

--- a/src/constants/mswPath.ts
+++ b/src/constants/mswPath.ts
@@ -2,5 +2,5 @@ export const api = {
   category: '/category?type=MOGAKKO',
   mgc: '/mogakko/map/228',
   address: 'https://dapi.kakao.com/v2/local/search/address.json',
-  mgcList: '/mogakko/map?searchType=LOCATION',
+  mgcList: '/mogakko/map',
 };

--- a/src/libs/test/mockZustandStore.tsx
+++ b/src/libs/test/mockZustandStore.tsx
@@ -1,4 +1,6 @@
 import { useThunderModalStore } from '@/store/thunderModalStore';
+import useKakaoMapLoad from '@/store/useKakaoMapLoad';
+import useSearchValueStore, { Position } from '@/store/useSearchValueStore';
 import { StoreApi } from 'zustand';
 
 type MockStore = <T>(hook: StoreApi<T>, state: Partial<T>) => void;
@@ -10,4 +12,12 @@ const mockStore: MockStore = (hook, state) => {
 
 export const mockUseThunderModalStore = (state: { isOpen: boolean }) => {
   mockStore(useThunderModalStore, state);
+};
+
+export const mockuseSearchValueStore = (state: { searchValue: Position }) => {
+  mockStore(useSearchValueStore, state);
+};
+
+export const mockUseKakaoMapLoadStore = (state: { isLoad: boolean }) => {
+  mockStore(useKakaoMapLoad, state);
 };

--- a/src/libs/test/render.tsx
+++ b/src/libs/test/render.tsx
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-export default async function async(component: ReactNode) {
+const setupRender = async (component: ReactNode) => {
   const user = userEvent.setup();
 
   const queryClient = new QueryClient({
@@ -25,4 +25,6 @@ export default async function async(component: ReactNode) {
     user,
     ...renderedComponent,
   };
-}
+};
+
+export default setupRender;

--- a/src/libs/test/render.tsx
+++ b/src/libs/test/render.tsx
@@ -1,9 +1,10 @@
 import { ReactNode } from 'react';
+import { getCategoryOptions } from '@/utils/getQueryOptions';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-export default function async(component: ReactNode) {
+export default async function async(component: ReactNode) {
   const user = userEvent.setup();
 
   const queryClient = new QueryClient({
@@ -13,6 +14,8 @@ export default function async(component: ReactNode) {
       },
     },
   });
+
+  await queryClient.prefetchQuery(getCategoryOptions());
 
   const renderedComponent = render(
     <QueryClientProvider client={queryClient}>{component}</QueryClientProvider>,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,6 +1,7 @@
 import { api } from '@/constants/mswPath';
 import { http } from 'msw';
 import response from './response';
+import addressList from './response/addressList.json';
 import mgcList from './response/mgcList.json';
 
 export const handlers = [
@@ -36,8 +37,13 @@ export const handlers = [
 
   http.get(api.address, ({ request }: { request: Request }) => {
     const query = new URL(request.url).searchParams.get('query');
-    if (query === '서초동') {
-      return new Response(JSON.stringify(response[api.address]), {
+
+    if (query) {
+      const address = addressList.documents.filter((e) =>
+        e.address_name.replace(/\d+/g, '').includes(query),
+      );
+
+      return new Response(JSON.stringify({ documents: address }), {
         headers: {
           'Content-Type': 'application/json',
         },

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,6 +1,7 @@
 import { api } from '@/constants/mswPath';
 import { http } from 'msw';
 import response from './response';
+import mgcList from './response/mgcList.json';
 
 export const handlers = [
   ...[api.category, api.mgc].map((path) =>
@@ -12,6 +13,27 @@ export const handlers = [
       });
     }),
   ),
+
+  http.get(api.mgcList, ({ request }: { request: Request }) => {
+    const search = new URL(request.url).searchParams.get('search');
+    const tags = new URL(request.url).searchParams.getAll('tags').map(Number);
+
+    if (search || tags) {
+      const filtedMgcList = mgcList.data.filter((item) => {
+        const matchesSearch = search ? item.location.address.includes(search) : true;
+        const matchesTags = tags.length > 0 ? tags.every((tag) => item.tags.includes(tag)) : true;
+
+        return matchesSearch && matchesTags;
+      });
+
+      return new Response(JSON.stringify({ data: filtedMgcList }), {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+    }
+  }),
+
   http.get(api.address, ({ request }: { request: Request }) => {
     const query = new URL(request.url).searchParams.get('query');
     if (query === '서초동') {

--- a/src/mocks/response/addressList.json
+++ b/src/mocks/response/addressList.json
@@ -69,6 +69,48 @@
       "sub_address_no": "",
       "x": "127.022170883244",
       "y": "37.5026854085131"
+    },
+    {
+      "address": {
+        "address_name": "경기 성남시 분당구 판교동",
+        "b_code": "4113510800",
+        "h_code": "4113565000",
+        "main_address_no": "",
+        "mountain_yn": "N",
+        "region_1depth_name": "경기",
+        "region_2depth_name": "성남시 분당구",
+        "region_3depth_h_name": "판교동",
+        "region_3depth_name": "판교동",
+        "sub_address_no": "",
+        "x": "127.09878136729",
+        "y": "37.3898680691971"
+      },
+      "address_name": "경기 성남시 분당구 판교동",
+      "address_type": "REGION",
+      "road_address": null,
+      "x": "127.09878136729",
+      "y": "37.3898680691971"
+    },
+    {
+      "address": {
+        "address_name": "충남 서천군 판교면",
+        "b_code": "4477038000",
+        "h_code": "4477038000",
+        "main_address_no": "",
+        "mountain_yn": "N",
+        "region_1depth_name": "충남",
+        "region_2depth_name": "서천군",
+        "region_3depth_h_name": "판교면",
+        "region_3depth_name": "판교면",
+        "sub_address_no": "",
+        "x": "126.689081928214",
+        "y": "36.1578198174349"
+      },
+      "address_name": "충남 서천군 판교면",
+      "address_type": "REGION",
+      "road_address": null,
+      "x": "126.689081928214",
+      "y": "36.1578198174349"
     }
   ]
 }

--- a/src/mocks/response/mgcList.json
+++ b/src/mocks/response/mgcList.json
@@ -27,16 +27,16 @@
       "maxParticipants": 8,
       "curParticipants": 1,
       "location": {
-        "address": "경상남도 창원시 진해구 석동",
-        "latitude": 35.1562585789,
-        "longitude": 128.7019449219,
-        "city": "경상남도 창원시 진해구 석동"
+        "address": "경기도 성남시 분당구 판교동",
+        "latitude": 37.38943118140635,
+        "longitude": 127.09756573957004,
+        "city": "경기도 성남시 분당구 판교동"
       },
       "tags": [239, 241, 242, 245, 247]
     },
     {
       "id": 230,
-      "title": "모각코",
+      "title": "모각코!",
       "views": 2,
       "likeCount": 0,
       "createdAt": "2024-05-13T15:56:08",
@@ -44,16 +44,16 @@
       "maxParticipants": 10,
       "curParticipants": 1,
       "location": {
-        "address": "경상남도 창원시 진해구 석동",
-        "latitude": 35.1567891055,
-        "longitude": 128.7020300465,
-        "city": "경상남도 창원시 진해구 석동"
+        "address": "경기도 성남시 분당구 판교동",
+        "latitude": 37.39119673991264,
+        "longitude": 127.09810442584084,
+        "city": "경기도 성남시 분당구 판교동"
       },
       "tags": [238, 240, 242, 244, 247]
     },
     {
       "id": 228,
-      "title": "모각코",
+      "title": "모각코~",
       "views": 78,
       "likeCount": 0,
       "createdAt": "2024-05-09T15:51:16",
@@ -61,10 +61,10 @@
       "maxParticipants": 10,
       "curParticipants": 2,
       "location": {
-        "address": "경상남도 창원시 진해구 석동",
-        "latitude": 35.158305423,
-        "longitude": 128.6993017131,
-        "city": "경상남도 창원시 진해구 석동"
+        "address": "경기도 성남시 분당구 판교동",
+        "latitude": 37.39091660412717,
+        "longitude": 127.0990865127028,
+        "city": "경기도 성남시 분당구 판교동"
       },
       "tags": [238, 240, 242, 244, 247]
     }

--- a/src/store/useSearchValueStore.ts
+++ b/src/store/useSearchValueStore.ts
@@ -6,7 +6,7 @@ interface SearchValueStore {
   setSearchValue: (newSearchValue: Position) => void;
 }
 
-interface Position {
+export interface Position {
   address?: string;
   tags?: number[];
 }

--- a/src/tests/CreateBtn.spec.tsx
+++ b/src/tests/CreateBtn.spec.tsx
@@ -1,5 +1,5 @@
 import CreateBtn from '@/app/_components/CreateBtn';
-import render from '@/libs/test/render';
+import setupRender from '@/libs/test/render';
 import { removeItem, setItem } from '@/utils/storage';
 import { screen } from '@testing-library/react';
 
@@ -19,7 +19,7 @@ vi.mock('next/navigation', async () => {
 describe('로그인 상태인 경우', () => {
   it('버튼 클릭시 모각코, 번개모각코 생성 버튼이 나타난다.', async () => {
     setItem(localStorage, 'token', 'token');
-    const { user } = await render(<CreateBtn />);
+    const { user } = await setupRender(<CreateBtn />);
 
     const buttons = screen.getAllByRole('button');
     const button = buttons[buttons.length - 1];
@@ -37,7 +37,7 @@ describe('로그인 상태인 경우', () => {
 describe('로그인이 되어 있지 않은 경우', () => {
   it('버튼 클릭 시 "/signin"경로와 함께 useRouter 함수가 호출된다', async () => {
     removeItem(localStorage, 'token');
-    const { user } = await render(<CreateBtn />);
+    const { user } = await setupRender(<CreateBtn />);
 
     const buttons = screen.getAllByRole('button');
     const button = buttons[buttons.length - 1];

--- a/src/tests/Filter.spec.tsx
+++ b/src/tests/Filter.spec.tsx
@@ -1,5 +1,5 @@
 import Filter from '@/app/_components/filter/Filter';
-import render from '@/libs/test/render';
+import setupRender from '@/libs/test/render';
 import useSearchValueStore from '@/store/useSearchValueStore';
 import { screen } from '@testing-library/react';
 import categoryList from '../mocks/response/categories.json';
@@ -11,7 +11,7 @@ global.ResizeObserver = class MockedResizeObserver {
 };
 
 const setup = async () => {
-  const { user } = await render(<Filter />);
+  const { user } = await setupRender(<Filter />);
   const accordionTriggerButton = screen.getByRole('button', { name: 'accordion trigger' });
 
   return {

--- a/src/tests/Filter.spec.tsx
+++ b/src/tests/Filter.spec.tsx
@@ -1,0 +1,70 @@
+import Filter from '@/app/_components/filter/Filter';
+import render from '@/libs/test/render';
+import useSearchValueStore from '@/store/useSearchValueStore';
+import { screen } from '@testing-library/react';
+import categoryList from '../mocks/response/categories.json';
+
+global.ResizeObserver = class MockedResizeObserver {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+};
+
+const setup = async () => {
+  const { user } = await render(<Filter />);
+  const accordionTriggerButton = screen.getByRole('button', { name: 'accordion trigger' });
+
+  return {
+    user,
+    accordionTriggerButton,
+  };
+};
+
+describe('Filter컴포넌트 테스트', () => {
+  it('카테고리 트리거를 클릭하지 않으면 필터 카테고리가 나타나지 않는다.', async () => {
+    await setup();
+
+    expect(screen.getByLabelText('accordion content')).not.toBeVisible();
+  });
+
+  it('카테고리 트리거를 클릭하면 필터 카테고리가 나타난다.', async () => {
+    const categoryTags = categoryList.data
+      .filter((e) => ['개발 언어', '개발 유형', '모각코 유형'].includes(e.category_name))
+      .flatMap((category) => category.tags);
+
+    const { user, accordionTriggerButton } = await setup();
+
+    await user.click(accordionTriggerButton);
+
+    for (const tag of categoryTags) {
+      expect(await screen.findByText(tag.tag_name)).toBeInTheDocument();
+    }
+  });
+
+  it.each([
+    { selectedLanguage: 'JS', selectedStudyArea: '코딩테스트', selectedMgcType: '일반' },
+    { selectedLanguage: 'Java', selectedStudyArea: 'BE' },
+    { selectedStudyArea: '코딩테스트' },
+  ])(
+    '필터를 선택하면 searchValue의 상태가 변경된다.',
+    async ({ selectedLanguage, selectedStudyArea, selectedMgcType }) => {
+      const selectedCategory = [selectedLanguage, selectedStudyArea, selectedMgcType];
+      const categoryTags = categoryList.data.flatMap((category) => category.tags);
+
+      const selectedTagIds = categoryTags
+        .filter((tag) => selectedCategory.includes(tag.tag_name))
+        .map((x) => x.tag_id);
+
+      const { user, accordionTriggerButton } = await setup();
+
+      await user.click(accordionTriggerButton);
+      if (selectedLanguage) await user.click(await screen.findByText(selectedLanguage));
+      if (selectedStudyArea) await user.click(await screen.findByText(selectedStudyArea));
+      if (selectedMgcType) await user.click(await screen.findByText(selectedMgcType));
+      await user.click(await screen.findByText('적용'));
+
+      const { tags } = useSearchValueStore.getState().searchValue;
+      expect(tags!.sort()).toEqual(selectedTagIds.sort());
+    },
+  );
+});

--- a/src/tests/Home.spec.tsx
+++ b/src/tests/Home.spec.tsx
@@ -1,0 +1,235 @@
+import Home from '@/app/(home)/page';
+import { geocodeAddressConversion } from '@/constants/geocodeAddressConversion';
+import { mockUseKakaoMapLoadStore, mockuseSearchValueStore } from '@/libs/test/mockZustandStore';
+import render from '@/libs/test/render';
+import { screen, waitFor } from '@testing-library/react';
+import categoryList from '../mocks/response/categories.json';
+import addressList from '../mocks/response/mgcList.json';
+
+vi.mock('next/navigation', async () => {
+  const original = await vi.importActual('next/navigation');
+
+  return {
+    ...original,
+    useRouter: () => ({
+      push: vi.fn(),
+    }),
+  };
+});
+
+Object.defineProperty(window.navigator, 'geolocation', {
+  value: {
+    getCurrentPosition: vi.fn().mockImplementation((success) =>
+      Promise.resolve(
+        success({
+          coords: {
+            latitude: 0,
+            longitude: 0,
+          },
+        }),
+      ),
+    ),
+  },
+  writable: true,
+});
+
+Object.defineProperty(window.navigator, 'permissions', {
+  value: {
+    query: vi.fn(() =>
+      Promise.resolve({
+        name: 'geolocation',
+        state: 'granted',
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+    ),
+  },
+  writable: true,
+});
+
+Object.defineProperty(window, 'scrollTo', {
+  value: vi.fn(),
+  writable: true,
+});
+
+const mockAddClustererMarkers = vi.fn().mockImplementation((markers) => markers);
+const mockSetMap = vi.fn();
+const mockSetDraggable = vi.fn();
+const mockGetPosition = vi.fn();
+const mockMarker = vi.fn().mockImplementation((options) => ({
+  setMap: mockSetMap,
+  setDraggable: mockSetDraggable,
+  getPosition: mockGetPosition,
+  options,
+}));
+const mockCoord2RegionCode = vi.fn();
+const mockSetCenter = vi.fn();
+const mockMarkerImage = vi.fn().mockImplementation((imageSrc) => ({ imageSrc }));
+const mockSize = vi.fn();
+const mockLatLng = vi.fn().mockImplementation((lat, lng) => ({ lat, lng }));
+const mockGeocoder = vi.fn().mockImplementation(() => ({
+  coord2RegionCode: mockCoord2RegionCode,
+}));
+
+const cmarker = vi.fn();
+const mockMarkerClusterer = vi.fn().mockImplementation(() => ({
+  clear: vi.fn(),
+  addMarkers: mockAddClustererMarkers,
+  markers: cmarker,
+}));
+
+global.kakao = {
+  maps: {
+    Map: vi.fn().mockImplementation(() => ({
+      setCenter: mockSetCenter,
+      addControl: vi.fn(),
+    })),
+    services: {
+      Geocoder: mockGeocoder,
+      Status: {
+        OK: 'OK',
+      },
+    },
+    MarkerClusterer: mockMarkerClusterer,
+    CustomOverlay: vi.fn().mockImplementation(() => ({
+      setMap: vi.fn(),
+    })),
+    LatLng: mockLatLng,
+    Marker: mockMarker,
+    Size: mockSize,
+    MarkerImage: mockMarkerImage,
+    Point: vi.fn(),
+    event: {
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    },
+    ZoomControl: vi.fn(),
+    ControlPosition: {
+      TOPRIGHT: 'TOPRIGHT',
+    },
+  },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;
+
+const setup = async (geocodeAddress: string) => {
+  mockCoord2RegionCode.mockImplementation((longitude, latitude, callback) => {
+    const result = geocodeAddressConversion[geocodeAddress];
+    callback(result, 'OK');
+  });
+
+  mockUseKakaoMapLoadStore({ isLoad: true });
+
+  const { user } = await render(<Home />);
+
+  const textInput = screen.getByPlaceholderText('동명(읍, 면)으로 검색(ex. 서초동).');
+  const ListShowButton = screen.getByText('목록보기');
+
+  return {
+    user,
+    textInput,
+    ListShowButton,
+  };
+};
+
+global.ResizeObserver = class MockedResizeObserver {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+};
+
+describe('Home컴포넌트', () => {
+  it('검색어 입력 후 주소를 선택하고 필터를 선택하면 해당하는 마커가 나타난다.', async () => {
+    const languageCategory = 'JS';
+    const studyAreaCategory = '코딩테스트';
+    const mgcTypeCategory = '일반';
+    const categorys = [languageCategory, studyAreaCategory, mgcTypeCategory];
+
+    const categoryTags = categoryList.data.flatMap((category) => category.tags);
+    const selectedTagIds = categoryTags
+      .filter((tag) => categorys.includes(tag.tag_name))
+      .map((x) => x.tag_id);
+
+    const resultAddress = addressList.data.filter(
+      (e) =>
+        e.location.address.includes('경기도 성남시 분당구 판교동') &&
+        selectedTagIds.every((tag) => e.tags.includes(tag)),
+    );
+
+    const markers = [];
+    for (const address of resultAddress) {
+      markers.push({
+        options: {
+          image: {
+            imageSrc: 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png',
+          },
+          position: { lat: address.location.latitude, lng: address.location.longitude },
+        },
+        setDraggable: mockSetDraggable,
+        setMap: mockSetMap,
+        getPosition: mockGetPosition,
+      });
+    }
+
+    const { user, textInput } = await setup('경기도 성남시 분당구 판교동');
+
+    await user.type(textInput, '판교');
+    await user.click(await screen.findByText('경기 성남시 분당구 판교동'));
+    await user.click(screen.getByRole('button', { name: 'accordion trigger' }));
+
+    const selectedLanguage = screen.getByText(languageCategory);
+    const selectedStudyArea = screen.getByText(studyAreaCategory);
+    const selectedMgcType = screen.getByText(mgcTypeCategory);
+
+    mockLatLng.mockClear();
+    mockMarker.mockClear();
+    mockAddClustererMarkers.mockClear();
+
+    await user.click(selectedLanguage);
+    await user.click(selectedStudyArea);
+    await user.click(selectedMgcType);
+    await user.click(screen.getByText('적용'));
+
+    expect(mockAddClustererMarkers).toBeCalledWith(markers);
+  });
+
+  it('해당 지역에 있는 모각코 리스트가 나타난다.', async () => {
+    const currentAddress = '서울특별시 서초구 서초1동';
+    mockuseSearchValueStore({ searchValue: { address: currentAddress, tags: undefined } });
+
+    const { user, ListShowButton } = await setup('서울특별시 서초구 서초1동');
+
+    await user.click(ListShowButton);
+
+    const resultAddress = addressList.data.filter((e) =>
+      e.location.address.includes(currentAddress),
+    );
+
+    await waitFor(async () => {
+      for (const address of resultAddress) {
+        const titleList = screen.getAllByText(address.title);
+        titleList.forEach((title) => expect(title).toBeInTheDocument());
+      }
+    });
+  });
+
+  it('서치바에 검색어를 입력하고, 목록버튼을 누르면 해당하는 모각코 리스트가 나열된다.', async () => {
+    const { user, textInput, ListShowButton } = await setup('서울특별시 서초구 서초1동');
+    await user.type(textInput, '서초동');
+    const address = await screen.findByText('서울 서초구 서초1동');
+
+    await user.click(address);
+    const resultAddress = addressList.data.filter((e) =>
+      e.location.address.includes('서울특별시 서초구 서초1동'),
+    );
+
+    await user.click(ListShowButton);
+
+    await waitFor(async () => {
+      for (const address of resultAddress) {
+        const titleList = screen.getAllByText(address.title);
+        titleList.forEach((title) => expect(title).toBeInTheDocument());
+      }
+    });
+  });
+});

--- a/src/tests/Home.spec.tsx
+++ b/src/tests/Home.spec.tsx
@@ -1,7 +1,7 @@
 import Home from '@/app/(home)/page';
 import { geocodeAddressConversion } from '@/constants/geocodeAddressConversion';
 import { mockUseKakaoMapLoadStore, mockuseSearchValueStore } from '@/libs/test/mockZustandStore';
-import render from '@/libs/test/render';
+import setupRender from '@/libs/test/render';
 import { screen, waitFor } from '@testing-library/react';
 import categoryList from '../mocks/response/categories.json';
 import addressList from '../mocks/response/mgcList.json';
@@ -120,7 +120,7 @@ const setup = async (geocodeAddress: string) => {
 
   mockUseKakaoMapLoadStore({ isLoad: true });
 
-  const { user } = await render(<Home />);
+  const { user } = await setupRender(<Home />);
 
   const textInput = screen.getByPlaceholderText('동명(읍, 면)으로 검색(ex. 서초동).');
   const ListShowButton = screen.getByText('목록보기');

--- a/src/tests/SearchBarFilter.spec.tsx
+++ b/src/tests/SearchBarFilter.spec.tsx
@@ -2,7 +2,7 @@ import { Address } from '@/apis/address/useAddressSearch';
 import AddressList from '@/app/(home)/_components/AddressList';
 import SearchBarFilter from '@/app/(home)/_components/SearchBarFilter';
 import { seochodongList } from '@/constants/searchResultAddressList';
-import render from '@/libs/test/render';
+import setupRender from '@/libs/test/render';
 import { screen, waitFor } from '@testing-library/react';
 import { UserEvent } from '@testing-library/user-event';
 
@@ -11,7 +11,7 @@ let textInput: HTMLElement;
 
 describe('SearchBarFilter 컴포넌트 테스트', () => {
   beforeEach(async () => {
-    const { user: currentUser } = await render(<SearchBarFilter />);
+    const { user: currentUser } = await setupRender(<SearchBarFilter />);
     user = currentUser;
     textInput = screen.getByPlaceholderText('동명(읍, 면)으로 검색(ex. 서초동).');
   });
@@ -49,7 +49,7 @@ describe('SearchBarFilter 컴포넌트 테스트', () => {
       mockSetShow(false);
     };
 
-    await render(
+    await setupRender(
       <AddressList
         address={seochodongList}
         onClick={mockHandleAddressClick}


### PR DESCRIPTION
## 📝 주요 작업 내용
- 홈페이지 통합테스트 작성
  - 사용자 입력에 따른 마커들 렌더 테스트
- 필터 컴포넌트 테스트 작성
- 검색 기능 버그 수정
  - 광역자치단체가 아닌 주소 검색 시 변환 과정이 필요해서 추가
- 필터 기능 버그 수정
  - useMGCTotalList의 매개변수에 tags가 누락되어 있어 추가

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷 스크린샷 (선택)

## 💬 고민 중인 부분 및 참고사항 (선택)

### 고민 중인 부분
사용자의 입력에 따른 마커 렌더 테스트를 하던 중 반복되는 동작에 대해 고민이 생겼습니다.

1. 검색어 입력시 나타나는 마커테스트
2. 필터 선택시 나타나는 마커테스트
3. 검색어 입력 + 필터 선택 시 마커테스트

이렇게 `단계별로 동작들이 더해지는 테스트`를 다하다보니 `중복되는 동작이 많았고` 모두 테스트 할 시 3번만 할때보다 `1초가량 차이`가 났습니다. 그래서 모든 동작을 하는 것보다 앞서 실행되는 작은 단위의 테스트를 추가하고 3번만 하는 방법을 생각했습니다. 

사용자 입력시 마커들이 나타나는 과정은 다음과 같습니다.
사용자 입력 -> 전역상태 변경 -> useQuery 실행 -> Marker컴포넌트의 props로 넘겨줄 값 변경

전역상태가 잘 변경된다면 후속 작업들이 잘될거라 생각하여 검색어입력과 필터 선택시 `전역상태 변경 테스트`를 추가하고 3번 테스트만 작성했습니다. 

- 모든 경우를 테스트하는 방법
  - 장점: 테스트 코드의 신뢰도가 높아집니다.
  - 단점: 반복되는 동작으로 인해 테스트 시간이 길어집니다.
- 최종동작만 테스트하고 전역상태가 변경되는 테스트를 추가하는 방법
  - 장점: 앞의 경우보다 테스트 시간이 줄어듭니다.
  - 단점: 앞의 경우보다는 코드의 신뢰도가 낮습니다.


더 좋은 방법이 있다면 알려주시면 무한감사하겠습니다!!🙇‍♀️
 
### 참고사항
- 카카오맵 api에 대한 모킹이 어마어마해서... 모킹을 최대한 없애는 방향으로 추후에 얼른 리팩토링 하겠습니다...!!


close #183 

