### PR TITLE
[#190] 카카오맵 래핑 클래스 생성 및 적용

### DIFF
--- a/src/app/(home)/_components/HomeMapViewer.tsx
+++ b/src/app/(home)/_components/HomeMapViewer.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import { MapContext } from '@/app/_components/Map/MapProvider';
 import MapViewer from '@/app/_components/Map/MapViewer';
+import useKakaoMapService from '@/libs/kakaoMapWrapper';
 import useInfoWindowPosition from '@/store/useInfoWindowPosition';
 
 interface HomeMapViewerProps {
@@ -18,6 +19,7 @@ interface HomeMapViewerProps {
 const HomeMapViewer = forwardRef(
   ({ timerRef, onMouseUp }: HomeMapViewerProps, mapRef: ForwardedRef<HTMLDivElement>) => {
     const map = useContext(MapContext);
+    const mapService = useKakaoMapService();
 
     const { setInfoWindowPosition } = useInfoWindowPosition();
 
@@ -42,7 +44,7 @@ const HomeMapViewer = forwardRef(
         if (map) {
           timerRef.current = setTimeout(() => {
             const mapProjection = map.getProjection();
-            const point = new kakao.maps.Point(e.touches[0].clientX, e.touches[0].clientY - 120);
+            const point = mapService.createPoint(e.touches[0].clientX, e.touches[0].clientY - 120);
             const latLng = mapProjection.coordsFromContainerPoint(point);
             setInfoWindowPosition({ latitude: latLng.getLat(), longitude: latLng.getLng() });
           }, 1000);
@@ -69,9 +71,9 @@ const HomeMapViewer = forwardRef(
       const mapContainer = document.getElementById('map')!;
 
       if (map) {
-        kakao.maps.event.addListener(map, 'mousedown', handleMouseDown);
-        kakao.maps.event.addListener(map, 'click', onMouseUp);
-        kakao.maps.event.addListener(map, 'dragstart', onMouseUp);
+        mapService.addListener(map, 'mousedown', handleMouseDown);
+        mapService.addListener(map, 'click', onMouseUp);
+        mapService.addListener(map, 'dragstart', onMouseUp);
         mapContainer.addEventListener('touchstart', handleTouchStart);
 
         findAllSvgElements(mapContainer);
@@ -79,9 +81,9 @@ const HomeMapViewer = forwardRef(
 
       return () => {
         if (map) {
-          kakao.maps.event.removeListener(map, 'mousedown', handleMouseDown);
-          kakao.maps.event.removeListener(map, 'click', onMouseUp);
-          kakao.maps.event.removeListener(map, 'dragstart', onMouseUp);
+          mapService.removeListener(map, 'mousedown', handleMouseDown);
+          mapService.removeListener(map, 'click', onMouseUp);
+          mapService.removeListener(map, 'dragstart', onMouseUp);
           mapContainer.removeEventListener('touchstart', handleTouchStart);
         }
       };

--- a/src/app/_components/Map/ClustererProvider.tsx
+++ b/src/app/_components/Map/ClustererProvider.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, createContext, useContext, useEffect, useState } from 'react';
+import useKakaoMapService from '@/libs/kakaoMapWrapper';
 import { MapContext } from './MapProvider';
 
 interface ClustererProps {
@@ -11,22 +12,22 @@ export const clustererContext = createContext<kakao.maps.MarkerClusterer | undef
 const ClustererProvider = ({ minLevel, children }: ClustererProps) => {
   const map = useContext(MapContext);
   const [clusterer, setClusterer] = useState<kakao.maps.MarkerClusterer>();
+  const mapService = useKakaoMapService();
 
   useEffect(() => {
     if (map) {
-      const clusterer = new kakao.maps.MarkerClusterer({
+      const clustererOption = {
         map: map, // 마커들을 클러스터로 관리하고 표시할 지도 객체
         averageCenter: true, // 클러스터에 포함된 마커들의 평균 위치를 클러스터 마커 위치로 설정
         minLevel: minLevel ?? 6, // 클러스터 할 최소 지도 레벨
         disableClickZoom: true, // 클러스터 마커를 클릭했을 때 지도가 확대되지 않도록 설정한다
         // disableClickZoom: false, // 클러스터 마커를 클릭했을 때 지도가 확대되도록 설정한다
-      });
+      };
+      const clusterer = mapService.createMarkerClusterer(clustererOption);
 
       setClusterer(clusterer);
     }
   }, [map, minLevel]);
-
-  //   console.log('clusterer', clusterer);
 
   return <clustererContext.Provider value={clusterer}>{children}</clustererContext.Provider>;
 };

--- a/src/app/_components/Map/GeocoderProvider.tsx
+++ b/src/app/_components/Map/GeocoderProvider.tsx
@@ -1,17 +1,20 @@
 'use client';
 
 import { ReactNode, createContext, useContext, useEffect, useState } from 'react';
+import useKakaoMapService from '@/libs/kakaoMapWrapper';
 import { MapContext } from './MapProvider';
 
 export const geocoderContext = createContext<kakao.maps.services.Geocoder | undefined>(undefined);
 
 const GeocoderProvider = ({ children }: { children: ReactNode }) => {
   const map = useContext(MapContext);
+  const mapService = useKakaoMapService();
+
   const [geocoder, setGeocoder] = useState<kakao.maps.services.Geocoder>();
 
   useEffect(() => {
     if (map) {
-      const geocoder = new kakao.maps.services.Geocoder();
+      const geocoder = mapService.createGeocoder();
 
       setGeocoder(geocoder);
     }

--- a/src/app/_components/Map/MapProvider.tsx
+++ b/src/app/_components/Map/MapProvider.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ReactNode, RefObject, createContext, useEffect, useState } from 'react';
+import useKakaoMapService from '@/libs/kakaoMapWrapper';
 import useKakaoMapLoad from '@/store/useKakaoMapLoad';
 
 interface MapProps {
@@ -14,23 +15,20 @@ export const MapContext = createContext<kakao.maps.Map | undefined>(undefined);
 
 const MapProvider = ({ isCustomlevelController, children, level, mapRef }: MapProps) => {
   const [map, setMap] = useState<kakao.maps.Map>();
+  const mapService = useKakaoMapService();
   const { isLoad } = useKakaoMapLoad();
 
   useEffect(() => {
     if (isLoad) {
       if (mapRef && mapRef.current != null) {
         const mapOption = {
-          center: new window.kakao.maps.LatLng(37.492074, 127.029781),
+          center: mapService.createLatLng(37.492074, 127.029781),
           level: level ?? 3,
         };
-
-        const createdMap = new window.kakao.maps.Map(mapRef.current, mapOption);
-
+        const createdMap = mapService.createMap(mapRef.current, mapOption);
         if (!isCustomlevelController) {
-          const zoomControl = new kakao.maps.ZoomControl();
-          createdMap.addControl(zoomControl, kakao.maps.ControlPosition.TOPRIGHT);
+          mapService.addZoomControl('TOPRIGHT');
         }
-
         setMap(createdMap);
       }
     }

--- a/src/app/_components/Map/Marker.tsx
+++ b/src/app/_components/Map/Marker.tsx
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useState } from 'react';
+import useKakaoMapService from '@/libs/kakaoMapWrapper';
 import { MapContext } from './MapProvider';
 
 interface MarkerProps {
@@ -15,6 +16,7 @@ interface MarkerProps {
 const Marker = ({ latitude, longitude, markerSrc, markerSize, draggble = false }: MarkerProps) => {
   const map = useContext(MapContext);
   const [mapMarker, setMapMarker] = useState<kakao.maps.Marker>();
+  const mapService = useKakaoMapService();
 
   useEffect(() => {
     if (map) {
@@ -24,19 +26,19 @@ const Marker = ({ latitude, longitude, markerSrc, markerSize, draggble = false }
         mapMarker.setMap(null);
       }
 
-      const movePosition = new kakao.maps.LatLng(latitude, longitude);
+      const movePosition = mapService.createLatLng(latitude, longitude);
       const imageSrc =
         markerSrc ?? 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_red.png';
-      const imageSize = new kakao.maps.Size(markerSize?.width ?? 64, markerSize?.height ?? 69);
+      const imageSize = mapService.createSize(markerSize?.width ?? 64, markerSize?.height ?? 69);
       const imageOption = {
-        offset: new kakao.maps.Point(
+        offset: mapService.createPoint(
           markerSize?.width ? markerSize?.width / 2 : 32,
           markerSize?.height ? markerSize?.height / 2 : 69 / 2,
         ),
       };
 
-      const markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize, imageOption);
-      const marker = new kakao.maps.Marker({
+      const markerImage = mapService.createMarkerImage(imageSrc, imageSize, imageOption);
+      const marker = mapService.createMarker({
         position: movePosition,
         image: markerImage,
       });

--- a/src/app/_components/infoWindow/InfoWindow.tsx
+++ b/src/app/_components/infoWindow/InfoWindow.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import useGetAddressByCoordinates from '@/hooks/useGetAddressByCoordinates';
+import useKakaoMapService from '@/libs/kakaoMapWrapper';
 import useCreatedPositionInfo from '@/store/useCreatedPositionInfo';
 import { MapContext } from '../Map/MapProvider';
 
@@ -16,6 +17,7 @@ type Location = { latitude: number; longitude: number };
 
 const InfoWindow = ({ show, position, children }: InfoWindow) => {
   const map = useContext(MapContext);
+  const mapService = useKakaoMapService();
 
   const [customoverlay, setCustomoverlay] = useState<kakao.maps.CustomOverlay>();
   const ref = useRef<HTMLDivElement | null>(null);
@@ -47,7 +49,8 @@ const InfoWindow = ({ show, position, children }: InfoWindow) => {
     if (map && customoverlay) {
       if (show) {
         customoverlay.setMap(map);
-        customoverlay.setPosition(new kakao.maps.LatLng(position.latitude, position.longitude));
+        const latLng = mapService.createLatLng(position.latitude, position.longitude);
+        customoverlay.setPosition(latLng);
       } else {
         customoverlay.setMap(null);
       }
@@ -56,11 +59,12 @@ const InfoWindow = ({ show, position, children }: InfoWindow) => {
 
   useEffect(() => {
     if (map) {
-      const customoverlay = new kakao.maps.CustomOverlay({
+      const customoverlayOption = {
         content: ref.current!,
-        position: new kakao.maps.LatLng(37.4767616, 126.9170176),
+        position: mapService.createLatLng(37.4767616, 126.9170176),
         clickable: true,
-      });
+      };
+      const customoverlay = mapService.createCustomOverlay(customoverlayOption);
 
       setCustomoverlay(customoverlay);
     }
@@ -94,7 +98,7 @@ const InfoWindow = ({ show, position, children }: InfoWindow) => {
       }
 
       // mousedown됐을 때의 커스텀 오버레이의 좌표에 실제로 마우스가 이동된 픽셀좌표를 반영합니다
-      const newPoint = new kakao.maps.Point(
+      const newPoint = mapService.createPoint(
         startOverlayPoint.current.x - deltaX,
         startOverlayPoint.current.y - deltaY,
       );
@@ -115,7 +119,7 @@ const InfoWindow = ({ show, position, children }: InfoWindow) => {
       const proj = map.getProjection(); // 지도 객체로 부터 화면픽셀좌표, 지도좌표간 변환을 위한 MapProjection 객체를 얻어옵니다
       const overlayPos = customoverlay.getPosition(); // 커스텀 오버레이의 현재 위치를 가져옵니다
 
-      const newPoint = new kakao.maps.Point(
+      const newPoint = mapService.createPoint(
         startOverlayPoint.current.x,
         startOverlayPoint.current.y,
       );

--- a/src/app/create/_components/CreateMGCMapViewer.tsx
+++ b/src/app/create/_components/CreateMGCMapViewer.tsx
@@ -11,6 +11,7 @@ import MapViewer from '@/app/_components/Map/MapViewer';
 import { LocationProps } from '@/app/create/_components/CreateMGC';
 import useGeolocation from '@/hooks/useGeolocation';
 import useGetAddressByCoordinates from '@/hooks/useGetAddressByCoordinates';
+import useKakaoMapService from '@/libs/kakaoMapWrapper';
 import { Location } from '../../_components/Map/MGCMap';
 
 interface CreateMGCMapViewerProps {
@@ -41,6 +42,7 @@ const CreateMGCMapViewer = forwardRef(
     mapRef: ForwardedRef<HTMLDivElement>,
   ) => {
     const map = useContext(MapContext);
+    const mapService = useKakaoMapService();
 
     const location = useGeolocation();
     const { getAddressByCoorinates } = useGetAddressByCoordinates();
@@ -81,14 +83,14 @@ const CreateMGCMapViewer = forwardRef(
 
     useEffect(() => {
       if (map) {
-        kakao.maps.event.addListener(map, 'click', handleMapClick);
-        kakao.maps.event.addListener(map, 'dragstart', onMouseUp);
+        mapService.addListener(map, 'click', handleMapClick);
+        mapService.addListener(map, 'dragstart', onMouseUp);
       }
 
       return () => {
         if (map) {
-          kakao.maps.event.removeListener(map, 'click', handleMapClick);
-          kakao.maps.event.removeListener(map, 'dragstart', onMouseUp);
+          mapService.removeListener(map, 'click', handleMapClick);
+          mapService.removeListener(map, 'dragstart', onMouseUp);
         }
       };
     }, [handleMapClick, map, onMouseUp]);

--- a/src/hooks/useChangeMapCenter.ts
+++ b/src/hooks/useChangeMapCenter.ts
@@ -1,13 +1,15 @@
 import { useCallback, useContext } from 'react';
 import { MapContext } from '@/app/_components/Map/MapProvider';
+import useKakaoMapService from '@/libs/kakaoMapWrapper';
 
 const useChangeMapCenter = () => {
   const map = useContext(MapContext);
+  const mapService = useKakaoMapService();
 
   const changeCenter = useCallback(
     (latitude: number, longitude: number) => {
       if (map) {
-        const movePosition = new kakao.maps.LatLng(latitude, longitude);
+        const movePosition = mapService.createLatLng(latitude, longitude);
         map.setCenter(movePosition);
       }
     },

--- a/src/hooks/useGetAddressByCoordinates.ts
+++ b/src/hooks/useGetAddressByCoordinates.ts
@@ -1,15 +1,17 @@
 import { useCallback, useContext } from 'react';
 import { geocoderContext } from '@/app/_components/Map/GeocoderProvider';
+import useKakaoMapService from '@/libs/kakaoMapWrapper';
 
 const useGetAddressByCoordinates = () => {
   const geocoder = useContext(geocoderContext);
+  const mapService = useKakaoMapService();
 
   const coord2RegionCodePromise = useCallback(
     (longitude: number, latitude: number): Promise<string> => {
       return new Promise((resolve, reject) => {
         if (geocoder) {
           geocoder.coord2RegionCode(longitude, latitude, (result, status) => {
-            if (status === kakao.maps.services.Status.OK) {
+            if (status === mapService.getServicesStatus('OK')) {
               let addressName = '';
               for (let i = 0; i < result.length; i++) {
                 if (result[i].region_type === 'H') {
@@ -17,7 +19,6 @@ const useGetAddressByCoordinates = () => {
                   break;
                 }
               }
-
               resolve(addressName);
             } else {
               reject(new Error('Geocoder failed'));

--- a/src/libs/kakaoMapWrapper.ts
+++ b/src/libs/kakaoMapWrapper.ts
@@ -1,0 +1,106 @@
+import { useContext } from 'react';
+import { MapContext } from '@/app/_components/Map/MapProvider';
+
+type ControlPositionKey = 'TOPLEFT' | 'TOPRIGHT' | 'BOTTOMLEFT' | 'BOTTOMRIGHT';
+type StatusKey = 'ERROR' | 'OK' | 'ZERO_RESULT';
+
+interface EventHandlers {
+  map: (e: kakao.maps.event.MouseEvent) => void;
+  cluster: (e: kakao.maps.Cluster) => void;
+}
+
+type EventHandler<T extends keyof EventHandlers> = EventHandlers[T];
+
+export class KakaoMapService {
+  map: kakao.maps.Map | undefined;
+  clusterer: kakao.maps.MarkerClusterer | undefined;
+
+  constructor(map: kakao.maps.Map | undefined) {
+    this.map = map;
+  }
+
+  addListener<T extends keyof EventHandlers>(
+    target: kakao.maps.event.EventTarget,
+    type: string,
+    handler: EventHandler<T>,
+  ): void {
+    window.kakao.maps.event.addListener(target, type, handler);
+  }
+
+  removeListener<T extends keyof EventHandlers>(
+    target: kakao.maps.event.EventTarget,
+    type: string,
+    handler: EventHandler<T>,
+  ): void {
+    window.kakao.maps.event.removeListener(target, type, handler);
+  }
+
+  getServicesStatus(status: StatusKey) {
+    const servicesStatus: StatusKey = status;
+
+    return window.kakao.maps.services.Status[servicesStatus];
+  }
+
+  createMap(container: HTMLElement, options: kakao.maps.MapOptions) {
+    this.map = new window.kakao.maps.Map(container, options);
+    return this.map;
+  }
+
+  createMarker(options: kakao.maps.MarkerOptions) {
+    return new kakao.maps.Marker(options);
+  }
+
+  createMarkerClusterer(options: kakao.maps.MarkerClustererOptions) {
+    this.clusterer = new kakao.maps.MarkerClusterer(options);
+    return this.clusterer;
+  }
+
+  createCustomOverlay(options: kakao.maps.CustomOverlayOptions) {
+    return new kakao.maps.CustomOverlay(options);
+  }
+
+  createPoint(x: number, y: number) {
+    return new kakao.maps.Point(x, y);
+  }
+
+  createSize(width: number, height: number) {
+    return new kakao.maps.Size(width, height);
+  }
+
+  createMarkerImage(
+    src: string,
+    size: kakao.maps.Size,
+    options?: kakao.maps.MarkerImageOptions | undefined,
+  ) {
+    return new kakao.maps.MarkerImage(src, size, options);
+  }
+
+  createLatLng(latitude: number, longitude: number) {
+    return new window.kakao.maps.LatLng(latitude, longitude);
+  }
+
+  createGeocoder() {
+    return new window.kakao.maps.services.Geocoder();
+  }
+
+  addMarkersInClusterer(markers: (kakao.maps.Marker | kakao.maps.CustomOverlay)[]) {
+    this.clusterer?.addMarkers(markers);
+  }
+
+  addZoomControl(position: ControlPositionKey) {
+    const controlPosition: ControlPositionKey = position;
+
+    if (this.map) {
+      const zoomControl = new window.kakao.maps.ZoomControl();
+      this.map.addControl(zoomControl, kakao.maps.ControlPosition[controlPosition]);
+    }
+  }
+}
+
+const useKakaoMapService = () => {
+  const map = useContext(MapContext);
+
+  return new KakaoMapService(map);
+};
+
+export default useKakaoMapService;

--- a/src/tests/Home.spec.tsx
+++ b/src/tests/Home.spec.tsx
@@ -6,6 +6,13 @@ import { screen, waitFor } from '@testing-library/react';
 import categoryList from '../mocks/response/categories.json';
 import addressList from '../mocks/response/mgcList.json';
 
+interface Marker {
+  position: {
+    latitude: number;
+    longitude: number;
+  };
+}
+
 vi.mock('next/navigation', async () => {
   const original = await vi.importActual('next/navigation');
 
@@ -53,64 +60,47 @@ Object.defineProperty(window, 'scrollTo', {
   writable: true,
 });
 
-const mockAddClustererMarkers = vi.fn().mockImplementation((markers) => markers);
-const mockSetMap = vi.fn();
-const mockSetDraggable = vi.fn();
-const mockGetPosition = vi.fn();
-const mockMarker = vi.fn().mockImplementation((options) => ({
-  setMap: mockSetMap,
-  setDraggable: mockSetDraggable,
-  getPosition: mockGetPosition,
-  options,
-}));
 const mockCoord2RegionCode = vi.fn();
-const mockSetCenter = vi.fn();
-const mockMarkerImage = vi.fn().mockImplementation((imageSrc) => ({ imageSrc }));
-const mockSize = vi.fn();
-const mockLatLng = vi.fn().mockImplementation((lat, lng) => ({ lat, lng }));
-const mockGeocoder = vi.fn().mockImplementation(() => ({
-  coord2RegionCode: mockCoord2RegionCode,
-}));
+const mockAddMarkersInClusterer = vi.fn().mockImplementation((markers) =>
+  markers.map((marker: Marker) => ({
+    latitude: marker.position.latitude,
+    longitude: marker.position.longitude,
+  })),
+);
 
-const cmarker = vi.fn();
-const mockMarkerClusterer = vi.fn().mockImplementation(() => ({
-  clear: vi.fn(),
-  addMarkers: mockAddClustererMarkers,
-  markers: cmarker,
-}));
+vi.mock('@/libs/kakaoMapWrapper', () => {
+  const createMockKakaoMapService = () => ({
+    createLatLng: vi.fn().mockImplementation((latitude, longitude) => ({
+      latitude,
+      longitude,
+    })),
+    createMap: vi.fn().mockImplementation(() => ({
+      setCenter: vi.fn(),
+    })),
+    addZoomControl: vi.fn(),
+    createGeocoder: vi.fn().mockImplementation(() => ({
+      coord2RegionCode: mockCoord2RegionCode,
+    })),
+    createMarkerClusterer: vi.fn().mockImplementation(() => ({
+      clear: vi.fn(),
+    })),
+    createSize: vi.fn(),
+    createMarkerImage: vi.fn(),
+    createCustomOverlay: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addMarkersInClusterer: mockAddMarkersInClusterer,
+    createMarker: vi.fn().mockImplementation((marker) => marker),
+    getServicesStatus: vi.fn().mockImplementation((status) => status),
+  });
 
-global.kakao = {
-  maps: {
-    Map: vi.fn().mockImplementation(() => ({
-      setCenter: mockSetCenter,
-      addControl: vi.fn(),
-    })),
-    services: {
-      Geocoder: mockGeocoder,
-      Status: {
-        OK: 'OK',
-      },
-    },
-    MarkerClusterer: mockMarkerClusterer,
-    CustomOverlay: vi.fn().mockImplementation(() => ({
-      setMap: vi.fn(),
-    })),
-    LatLng: mockLatLng,
-    Marker: mockMarker,
-    Size: mockSize,
-    MarkerImage: mockMarkerImage,
-    Point: vi.fn(),
-    event: {
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-    },
-    ZoomControl: vi.fn(),
-    ControlPosition: {
-      TOPRIGHT: 'TOPRIGHT',
-    },
-  },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-} as any;
+  const mockKakaoMapService = vi.fn().mockImplementation(createMockKakaoMapService);
+
+  return {
+    default: mockKakaoMapService,
+    KakaoMapService: mockKakaoMapService,
+  };
+});
 
 const setup = async (geocodeAddress: string) => {
   mockCoord2RegionCode.mockImplementation((longitude, latitude, callback) => {

--- a/src/tests/Home.spec.tsx
+++ b/src/tests/Home.spec.tsx
@@ -146,21 +146,6 @@ describe('Home컴포넌트', () => {
         selectedTagIds.every((tag) => e.tags.includes(tag)),
     );
 
-    const markers = [];
-    for (const address of resultAddress) {
-      markers.push({
-        options: {
-          image: {
-            imageSrc: 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png',
-          },
-          position: { lat: address.location.latitude, lng: address.location.longitude },
-        },
-        setDraggable: mockSetDraggable,
-        setMap: mockSetMap,
-        getPosition: mockGetPosition,
-      });
-    }
-
     const { user, textInput } = await setup('경기도 성남시 분당구 판교동');
 
     await user.type(textInput, '판교');
@@ -171,16 +156,25 @@ describe('Home컴포넌트', () => {
     const selectedStudyArea = screen.getByText(studyAreaCategory);
     const selectedMgcType = screen.getByText(mgcTypeCategory);
 
-    mockLatLng.mockClear();
-    mockMarker.mockClear();
-    mockAddClustererMarkers.mockClear();
+    mockAddMarkersInClusterer.mockClear();
 
     await user.click(selectedLanguage);
     await user.click(selectedStudyArea);
     await user.click(selectedMgcType);
     await user.click(screen.getByText('적용'));
 
-    expect(mockAddClustererMarkers).toBeCalledWith(markers);
+    expect(mockAddMarkersInClusterer).toHaveBeenCalledWith(
+      expect.arrayContaining(
+        resultAddress.map((address) =>
+          expect.objectContaining({
+            position: {
+              latitude: address.location.latitude,
+              longitude: address.location.longitude,
+            },
+          }),
+        ),
+      ),
+    );
   });
 
   it('해당 지역에 있는 모각코 리스트가 나타난다.', async () => {


### PR DESCRIPTION
## 📝 주요 작업 내용
- 카카오 맵 api 기능을 래핑한 클래스 생성
- 해당 클래스를 이용하는 것으로 변경
- 전역 객체 모킹에서 클래스 모킹으로 변경
 
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷 스크린샷 (선택)

## 💬 고민 중인 부분 및 참고사항 (선택)
외부 api를 테스트시 모킹관련 자료를 찾아보다 [Please don't mock me](https://www.youtube.com/watch?v=x8sKpJwq6lY)라는 자료를 봤습니다. 이 발표에서는 외부 API를 직접 모킹하는 대신, 이를 래핑한 클래스를 모킹할 것을 권장하고 있습니다. 

### 래핑 시 장점
1. 모킹이 쉬워진다.
1. 외부 api와의 응집도를 낮춰 api 변경시 대응에 편리하다.
2. 만약 지도api를 변경할 때 래핑한 클래스의 내용만 변경하면 된다.

이 세가지의 장점을 보고 리팩토링을 결심했습니다. 하지만 모킹 측면에서는 생각보다 많은 이점을 느끼지 못했습니다. (실제로 코드가 5줄 줄었습니다............................😇)

그래도 전역 객체를 모킹할 때는 사용되는 모든 것을 모킹해줘야 하는 반면, 래핑 클래스를 모킹할 때는 몇몇 부분을 생략할 수 있었습니다. 모킹 양에 관한 이점에 대해서는 다른 부분들도 테스트해보고 최종 판단을 내릴 수 있을 것 같습니다!

### 리팩토링 후의 한계와 고민
1. 모킹이 쉬워진다.
    ⇒ 단위 테스트가 아닌 통합테스트인 home테스트에서는 모킹이 많이 필요해서 대단한 효과는 체감하지 못했습니다.
2. 외부 api와의 응집도를 낮춰 api 변경시 대응에 편리하다.
    ⇒ 21년도가 마지막 업데이트라 다소 안정된 api라서 변경이 일어날 가능성이 적습니다.
3. 만약 지도api를 변경할 때 래핑한 클래스의 내용만 변경하면 된다.
    ⇒ 기획이 변경되지 않는 한 지도가 변경되지 않을 가능성이 높습니다.

이러한 점들 때문에 오버엔지니어링은 아닌지 고민이 되어서... 다른 분들의 의견을 듣고 싶습니다. 피드백 부탁드립니다!

close #190 

