### PR TITLE
[#220] 테스트 초기화 방식을 beforeEach에서 setup 함수로 전환 및 모킹 코드 유틸리티화

### DIFF
--- a/src/libs/test/mockWindowUtils.ts
+++ b/src/libs/test/mockWindowUtils.ts
@@ -1,36 +1,63 @@
-export const mockGeolocation = () => {
-  Object.defineProperty(window.navigator, 'geolocation', {
-    value: {
-      getCurrentPosition: vi.fn().mockImplementation((success) =>
-        Promise.resolve(
-          success({
-            coords: {
-              latitude: 0,
-              longitude: 0,
-            },
-          }),
+export const mockGeolocation = {
+  granted: (coords: { latitude: number; longitude: number }) => {
+    Object.defineProperty(window.navigator, 'geolocation', {
+      value: {
+        getCurrentPosition: vi.fn().mockImplementation((success) =>
+          Promise.resolve(
+            success({
+              coords,
+            }),
+          ),
         ),
-      ),
-    },
-    writable: true,
-  });
+      },
+      writable: true,
+    });
+  },
+  denied: () => {
+    Object.defineProperty(window.navigator, 'geolocation', {
+      value: {
+        getCurrentPosition: vi
+          .fn()
+          .mockImplementation((success, error) => Promise.resolve(error())),
+      },
+      writable: true,
+    });
+  },
 };
 
-export const mockPermissions = () => {
-  Object.defineProperty(window.navigator, 'permissions', {
-    value: {
-      query: vi.fn(() =>
-        Promise.resolve({
-          name: 'geolocation',
-          state: 'granted',
-          onchange: null,
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn(),
-        }),
-      ),
-    },
-    writable: true,
-  });
+export const mockPermissions = {
+  granted: () => {
+    Object.defineProperty(window.navigator, 'permissions', {
+      value: {
+        query: vi.fn(() =>
+          Promise.resolve({
+            name: 'geolocation',
+            state: 'granted',
+            onchange: null,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+          }),
+        ),
+      },
+      writable: true,
+    });
+  },
+  denied: () => {
+    Object.defineProperty(window.navigator, 'permissions', {
+      value: {
+        query: vi.fn(() =>
+          Promise.resolve({
+            name: 'geolocation',
+            state: 'denied',
+            onchange: null,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+          }),
+        ),
+      },
+      writable: true,
+    });
+  },
 };
 
 export const mockScrollTo = () => {

--- a/src/libs/test/mockWindowUtils.ts
+++ b/src/libs/test/mockWindowUtils.ts
@@ -63,11 +63,3 @@ export const mockPermissions = {
 export const mockScrollTo = () => {
   Object.defineProperty(window, 'scrollTo', { value: vi.fn(), writable: true });
 };
-
-export const mockResizeObserver = () => {
-  global.ResizeObserver = class MockedResizeObserver {
-    observe = vi.fn();
-    unobserve = vi.fn();
-    disconnect = vi.fn();
-  };
-};

--- a/src/libs/test/mockWindowUtils.ts
+++ b/src/libs/test/mockWindowUtils.ts
@@ -1,0 +1,46 @@
+export const mockGeolocation = () => {
+  Object.defineProperty(window.navigator, 'geolocation', {
+    value: {
+      getCurrentPosition: vi.fn().mockImplementation((success) =>
+        Promise.resolve(
+          success({
+            coords: {
+              latitude: 0,
+              longitude: 0,
+            },
+          }),
+        ),
+      ),
+    },
+    writable: true,
+  });
+};
+
+export const mockPermissions = () => {
+  Object.defineProperty(window.navigator, 'permissions', {
+    value: {
+      query: vi.fn(() =>
+        Promise.resolve({
+          name: 'geolocation',
+          state: 'granted',
+          onchange: null,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        }),
+      ),
+    },
+    writable: true,
+  });
+};
+
+export const mockScrollTo = () => {
+  Object.defineProperty(window, 'scrollTo', { value: vi.fn(), writable: true });
+};
+
+export const mockResizeObserver = () => {
+  global.ResizeObserver = class MockedResizeObserver {
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+  };
+};

--- a/src/tests/Home.spec.tsx
+++ b/src/tests/Home.spec.tsx
@@ -1,5 +1,6 @@
 import Home from '@/app/(home)/page';
 import { geocodeAddressConversion } from '@/constants/geocodeAddressConversion';
+import { mockGeolocation, mockPermissions, mockScrollTo } from '@/libs/test/mockWindowUtils';
 import { mockUseKakaoMapLoadStore, mockuseSearchValueStore } from '@/libs/test/mockZustandStore';
 import setupRender from '@/libs/test/render';
 import { screen, waitFor } from '@testing-library/react';
@@ -22,42 +23,6 @@ vi.mock('next/navigation', async () => {
       push: vi.fn(),
     }),
   };
-});
-
-Object.defineProperty(window.navigator, 'geolocation', {
-  value: {
-    getCurrentPosition: vi.fn().mockImplementation((success) =>
-      Promise.resolve(
-        success({
-          coords: {
-            latitude: 0,
-            longitude: 0,
-          },
-        }),
-      ),
-    ),
-  },
-  writable: true,
-});
-
-Object.defineProperty(window.navigator, 'permissions', {
-  value: {
-    query: vi.fn(() =>
-      Promise.resolve({
-        name: 'geolocation',
-        state: 'granted',
-        onchange: null,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-      }),
-    ),
-  },
-  writable: true,
-});
-
-Object.defineProperty(window, 'scrollTo', {
-  value: vi.fn(),
-  writable: true,
 });
 
 const mockCoord2RegionCode = vi.fn();
@@ -127,6 +92,12 @@ global.ResizeObserver = class MockedResizeObserver {
   unobserve = vi.fn();
   disconnect = vi.fn();
 };
+
+beforeAll(() => {
+  mockGeolocation();
+  mockPermissions();
+  mockScrollTo();
+});
 
 describe('Home컴포넌트', () => {
   it('검색어 입력 후 주소를 선택하고 필터를 선택하면 해당하는 마커가 나타난다.', async () => {

--- a/src/tests/Home.spec.tsx
+++ b/src/tests/Home.spec.tsx
@@ -93,9 +93,14 @@ global.ResizeObserver = class MockedResizeObserver {
   disconnect = vi.fn();
 };
 
+const mockCoords = {
+  latitude: 0,
+  longitude: 0,
+};
+
 beforeAll(() => {
-  mockGeolocation();
-  mockPermissions();
+  mockPermissions['granted']();
+  mockGeolocation['granted'](mockCoords);
   mockScrollTo();
 });
 

--- a/src/tests/SearchBarFilter.spec.tsx
+++ b/src/tests/SearchBarFilter.spec.tsx
@@ -4,23 +4,24 @@ import HomeSearchBarFilter from '@/app/(home)/_components/HomeSearchBarFilter';
 import { seochodongList } from '@/constants/searchResultAddressList';
 import setupRender from '@/libs/test/render';
 import { screen, waitFor } from '@testing-library/react';
-import { UserEvent } from '@testing-library/user-event';
 
-let user: UserEvent;
-let textInput: HTMLElement;
+const setup = async () => {
+  const { user } = await setupRender(<HomeSearchBarFilter />);
+  const textInput = screen.getByPlaceholderText('동명(읍, 면)으로 검색(ex. 서초동)');
+
+  return { user, textInput };
+};
 
 describe('SearchBarFilter 컴포넌트 테스트', () => {
-  beforeEach(async () => {
-    const { user: currentUser } = await setupRender(<HomeSearchBarFilter />);
-    user = currentUser;
-    textInput = screen.getByPlaceholderText('동명(읍, 면)으로 검색(ex. 서초동)');
-  });
+  it('검색어 입력 전에는 AddressList 컴포넌트가 렌더되지 않는다.', async () => {
+    await setup();
 
-  it('검색어 입력 전에는 AddressList 컴포넌트가 렌더되지 않는다.', () => {
     expect(screen.queryByTestId('address-container')).not.toBeInTheDocument();
   });
 
   it('"서초동" 검색 시 서초동에 해당하는 주소리스트가 나타난다.', async () => {
+    const { user, textInput } = await setup();
+
     await user.type(textInput, '서초동');
 
     await waitFor(() => {
@@ -32,12 +33,16 @@ describe('SearchBarFilter 컴포넌트 테스트', () => {
   });
 
   it('결과값이 없는 주소를 검색했을 시 "검색 결과가 없어요"가 나타난다.', async () => {
+    const { user, textInput } = await setup();
+
     await user.type(textInput, '없음');
     const item = screen.getByText('검색 결과가 없어요');
     expect(item).toBeInTheDocument();
   });
 
   it('주소 리스트에서 "서울 서초구 서초동" 텍스트 클릭하면 handleAddressClick이 호출된다.', async () => {
+    const { user } = await setup();
+
     const mockChangeCenter = vi.fn();
     const mockChangeAddress = vi.fn();
     const mockSetShow = vi.fn();

--- a/src/tests/useGeolocation.spec.tsx
+++ b/src/tests/useGeolocation.spec.tsx
@@ -1,5 +1,6 @@
 import { toast } from '@/components/ui/use-toast';
 import useGeolocation from '@/hooks/useGeolocation';
+import { mockGeolocation, mockPermissions } from '@/libs/test/mockWindowUtils';
 import { act, renderHook } from '@testing-library/react';
 
 const mockPush = vi.fn();
@@ -24,40 +25,9 @@ const mockCoords = {
   longitude: 10,
 };
 
-const mockGeolocationPermission = (state: string) => {
-  Object.defineProperty(window.navigator, 'geolocation', {
-    value: {
-      getCurrentPosition: vi.fn().mockImplementation((success, error) =>
-        Promise.resolve(
-          state === 'granted'
-            ? success({
-                coords: mockCoords,
-              })
-            : error(),
-        ),
-      ),
-    },
-    writable: true,
-  });
-
-  Object.defineProperty(window.navigator, 'permissions', {
-    value: {
-      query: vi.fn(() =>
-        Promise.resolve({
-          name: 'geolocation',
-          state: state,
-          onchange: null,
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn(),
-        }),
-      ),
-    },
-    writable: true,
-  });
-};
-
 const setup = async (state: 'granted' | 'denied') => {
-  mockGeolocationPermission(state);
+  mockPermissions[state]();
+  mockGeolocation[state](mockCoords);
 
   return await act(async () => {
     const { result } = renderHook(() => useGeolocation());

--- a/src/tests/useGeolocation.spec.tsx
+++ b/src/tests/useGeolocation.spec.tsx
@@ -1,10 +1,6 @@
 import { toast } from '@/components/ui/use-toast';
-import useGeolocation, { LocationType } from '@/hooks/useGeolocation';
+import useGeolocation from '@/hooks/useGeolocation';
 import { act, renderHook } from '@testing-library/react';
-
-interface HookResult {
-  current: LocationType;
-}
 
 const mockPush = vi.fn();
 
@@ -60,25 +56,28 @@ const mockGeolocationPermission = (state: string) => {
   });
 };
 
-describe('위치 접근 권한을 허용한 경우', () => {
-  let hookResult: HookResult = {} as HookResult;
+const setup = async (state: 'granted' | 'denied') => {
+  mockGeolocationPermission(state);
 
-  beforeEach(async () => {
-    mockGeolocationPermission('granted');
+  return await act(async () => {
+    const { result } = renderHook(() => useGeolocation());
 
-    await act(async () => {
-      const { result } = renderHook(() => useGeolocation());
-      hookResult = result;
-    });
+    return { result };
   });
+};
 
-  it('toast메시지가 나타나지 않는다.', () => {
+describe('위치 접근 권한을 허용한 경우', () => {
+  it('toast메시지가 나타나지 않는다.', async () => {
+    await setup('granted');
+
     expect(toast).not.toBeCalled();
   });
 
-  it('현재 위치 좌표와 loaded값을 담은 객체를 반환한다.', () => {
-    expect(hookResult.current.loaded).toEqual(true);
-    expect(hookResult.current.coordinates).toEqual({
+  it('현재 위치 좌표와 loaded값을 담은 객체를 반환한다.', async () => {
+    const { result } = await setup('granted');
+
+    expect(result.current.loaded).toEqual(true);
+    expect(result.current.coordinates).toEqual({
       lat: mockCoords.latitude,
       lng: mockCoords.longitude,
     });
@@ -87,11 +86,7 @@ describe('위치 접근 권한을 허용한 경우', () => {
 
 describe('위치 접근 권한을 허용하지 않은 경우', () => {
   it("'💡 위치정보를 허용하지 않으면 현재 위치가 표시되지 않습니다!'문구의 toast메시지가 나타난다.", async () => {
-    mockGeolocationPermission('denied');
-
-    await act(async () => {
-      renderHook(() => useGeolocation());
-    });
+    await setup('denied');
 
     expect(toast).toBeCalledWith({
       description: '💡 위치정보를 허용하지 않으면 현재 위치가 표시되지 않습니다!',


### PR DESCRIPTION
## 📝 주요 작업 내용
- beforeEahc로 초기화 하는 파일에서 setup함수 생성 및 적용
- window.navigator 모킹 유틸함수화 및 적용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷 스크린샷 (선택)

## 💬 고민 중인 부분 및 참고사항 (선택)


close #220

